### PR TITLE
Gaufrette fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     },
 
     "target-dir": "Dizda/CloudBackupBundle",
-    "minimum-stability": "dev",
 
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Folks at KnpLabs/KnpGaufretteBundle just released a new stable [version 0.1.7](https://github.com/KnpLabs/KnpGaufretteBundle/releases/tag/v0.1.7)

Updated composer.json accordingly, removed stability-flag and gaufrette library as it is handled by bundles composer.json.
