### PR TITLE
Fixed cleanUp problem

### DIFF
--- a/Databases/BaseDatabase.php
+++ b/Databases/BaseDatabase.php
@@ -95,8 +95,8 @@ abstract class BaseDatabase
      */
     final public function cleanUp()
     {
-        $this->filesystem->remove($this->basePath);
         $this->filesystem->remove($this->compressedArchivePath);
+        $this->filesystem->remove($this->basePath);
     }
 
 


### PR DESCRIPTION
cleanUp function doesn't work in my computer. It is because after remove "db" folder, remove function can't find path "db/../" because "db" is already removed. If I changed the order of remove calls in cleanUp function it works. 
