### PR TITLE
Folders backup

### DIFF
--- a/Command/BackupCommand.php
+++ b/Command/BackupCommand.php
@@ -26,8 +26,15 @@ class BackupCommand extends ContainerAwareCommand
 
     protected function configure()
     {
-        $this->setName('dizda:backup:start')
-             ->setDescription('Upload a backup of your database to cloud service\'s');
+        $this
+            ->addOption(
+                'folders',
+                'F',
+                 InputOption::VALUE_NONE,
+                'Do you want to export also folders?'
+                )
+            ->setName('dizda:backup:start')
+            ->setDescription('Upload a backup of your database to cloud services (use -F option for backup folders)');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -72,6 +79,11 @@ class BackupCommand extends ContainerAwareCommand
             $this->output->writeln('<info>OK</info>');
         }
 
+        if($input->getOption('folders')){
+            $this->output->write('- <comment>Copying folders...</comment>');
+            $database->copyFolders();
+            $this->output->writeln('<info>OK</info>');
+        }
         $database->compression();
         $this->output->writeln('- <info>Archive created</info> ' . $database->getArchivePath());
 

--- a/Databases/BaseDatabase.php
+++ b/Databases/BaseDatabase.php
@@ -21,16 +21,18 @@ abstract class BaseDatabase
     protected $dataPath;
     protected $archivePath;
     protected $compressedArchivePath;
-
+    protected $folders;
 
     /**
      * Get SF2 Filesystem
      *
      * @param string $filePrefix
+     * @param string $folders
      */
-    public function __construct($filePrefix)
+    public function __construct($filePrefix, $folders)
     {
         $this->filePrefix = $filePrefix;
+        $this->folders=$folders;
         $this->filesystem = new Filesystem();
     }
 
@@ -53,6 +55,15 @@ abstract class BaseDatabase
         $this->filesystem->mkdir($this->dataPath);
     }
 
+    /**
+    * Make a copy of all folders in specified in config
+    */
+    final public function copyFolders(){
+        // Copy folder for compresion file
+        foreach($this->folders as $folder){
+            $this->filesystem->mirror($this->basePath.'../../../../'.$folder, $this->basePath.$folder);     
+        }            
+    }
 
     /**
      * Compress with format name like : hostname_2013_01_12-00_06_40.tar

--- a/Databases/MongoDB.php
+++ b/Databases/MongoDB.php
@@ -26,9 +26,9 @@ class MongoDB extends BaseDatabase
      * @param string $password
      * @param string $filePrefix
      */
-    public function __construct($allDatabases, $host, $port = 27017, $database, $user, $password, $filePrefix)
+    public function __construct($allDatabases, $host, $port = 27017, $database, $user, $password, $filePrefix, $folders)
     {
-        parent::__construct($filePrefix);
+        parent::__construct($filePrefix, $folders);
 
         $this->allDatabases = $allDatabases;
         $this->database     = $database;

--- a/Databases/MySQL.php
+++ b/Databases/MySQL.php
@@ -27,9 +27,9 @@ class MySQL extends BaseDatabase
      * @param string $password
      * @param string $filePrefix
      */
-    public function __construct($allDatabases, $host, $port = 3306, $database, $user, $password, $filePrefix)
+    public function __construct($allDatabases, $host, $port = 3306, $database, $user, $password, $filePrefix, $folders)
     {
-        parent::__construct($filePrefix);
+        parent::__construct($filePrefix, $folders);
 
         $this->allDatabases = $allDatabases;
         $this->database     = $database;

--- a/Databases/PostgreSQL.php
+++ b/Databases/PostgreSQL.php
@@ -27,9 +27,9 @@ class PostgreSQL extends BaseDatabase
      * @param string $password
      * @param string $filePrefix
      */
-    public function __construct($host = 'localhost', $port = 5432, $database, $user, $password, $filePrefix)
+    public function __construct($host = 'localhost', $port = 5432, $database, $user, $password, $filePrefix, $folders)
     {
-        parent::__construct($filePrefix);
+        parent::__construct($filePrefix, $folders);
 
         $this->database   = $database;
         $this->auth       = '';

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
         ->children()
             ->scalarNode('output_file_prefix')->defaultValue(gethostname())->end()
+            ->arrayNode('folders')->prototype('scalar')->end()->end()
             ->arrayNode('cloud_storages')
                 ->children()
                     ->arrayNode('dropbox')

--- a/DependencyInjection/DizdaCloudBackupExtension.php
+++ b/DependencyInjection/DizdaCloudBackupExtension.php
@@ -27,7 +27,8 @@ class DizdaCloudBackupExtension extends Extension
 
         /* Config output file */
         $container->setParameter('dizda_cloud_backup.output_file_prefix', $config['output_file_prefix']);
-
+        $container->setParameter('dizda_cloud_backup.folders', $config['folders']);
+        
         /* Config dropbox */
         if (isset($config['cloud_storages']['dropbox'])) {
             $container->setParameter('dizda_cloud_backup.cloud_storages.dropbox.active',      true);

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ dizda_cloud_backup:
     # By default backup files will have your servers hostname as prefix
     # such as: hostname_2014_01_01-21_08_39.tar
     output_file_prefix: hostname 
+    folders: [ web/uploads , other/folder ]
     cloud_storages:
         # Dropbox account credentials (use parameters in config.yml and store real values in prameters.yml)
         dropbox:
@@ -174,6 +175,8 @@ $ php app/console dizda:backup:start
 ```
 
 ![](https://github.com/dizda/CloudBackupBundle/raw/master/Resources/doc/dizda-Cloud-Backup-Bundle-symfony2.png)
+
+In addition, using -F or --folder option the folders also will be added to the backup.
 
 Capifony integration
 --------------------

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,6 +25,7 @@ services:
             - %dizda_cloud_backup.databases.mongodb.db_user%
             - %dizda_cloud_backup.databases.mongodb.db_password%
             - %dizda_cloud_backup.output_file_prefix%
+            - %dizda_cloud_backup.folders%            
         calls:
             - [setKernelCacheDir, ["%kernel.cache_dir%"]]
 
@@ -38,6 +39,7 @@ services:
             - %dizda_cloud_backup.databases.mysql.db_user%
             - %dizda_cloud_backup.databases.mysql.db_password%
             - %dizda_cloud_backup.output_file_prefix%
+            - %dizda_cloud_backup.folders%            
         calls:
             - [setKernelCacheDir, ["%kernel.cache_dir%"]]
 
@@ -50,5 +52,6 @@ services:
             - %dizda_cloud_backup.databases.postgresql.db_user%
             - %dizda_cloud_backup.databases.postgresql.db_password%
             - %dizda_cloud_backup.output_file_prefix%
+            - %dizda_cloud_backup.folders%            
         calls:
             - [setKernelCacheDir, ["%kernel.cache_dir%"]]

--- a/Tests/Databases/MongoDBTest.php
+++ b/Tests/Databases/MongoDBTest.php
@@ -19,15 +19,15 @@ class MongoDBTest extends AbstractTesting
         $mongodb = self::$kernel->getContainer()->get('dizda.cloudbackup.database.mongodb');
 
         // dump all dbs
-        $mongodb->__construct(true, 'localhost', 27017, 'dizbdd', null, null, 'localhost');
+        $mongodb->__construct(true, 'localhost', 27017, 'dizbdd', null, null, 'localhost', array());
         $this->assertEquals($mongodb->getCommand(), 'mongodump -h localhost --port 27017  --out ');
 
         // dump one db with not auth
-        $mongodb->__construct(false, 'localhost', 27017, 'dizbdd', null, null, 'localhost');
+        $mongodb->__construct(false, 'localhost', 27017, 'dizbdd', null, null, 'localhost', array());
         $this->assertEquals($mongodb->getCommand(), 'mongodump -h localhost --port 27017 --db dizbdd --out ');
 
         // dump one db with auth
-        $mongodb->__construct(false, 'localhost', 27017, 'dizbdd', 'dizda', 'imRootBro', 'localhost');
+        $mongodb->__construct(false, 'localhost', 27017, 'dizbdd', 'dizda', 'imRootBro', 'localhost', array());
         $this->assertEquals($mongodb->getCommand(), 'mongodump -h localhost --port 27017 -u dizda -p imRootBro --db dizbdd --out ');
     }
 

--- a/Tests/Databases/MySQLTest.php
+++ b/Tests/Databases/MySQLTest.php
@@ -17,25 +17,25 @@ class MySQLTest extends AbstractTesting
     public function testGetCommand()
     {
         $mysql = self::$kernel->getContainer()->get('dizda.cloudbackup.database.mysql');
-        $mysql->__construct(true, 'localhost', 3306, 'dizbdd', 'root', 'test', 'localhost');
+        $mysql->__construct(true, 'localhost', 3306, 'dizbdd', 'root', 'test', 'localhost', array());
 
         // dump all databases
         $this->assertEquals($mysql->getCommand(), 'mysqldump --host=localhost --port=3306 --user=root --password=test --all-databases > all-databases.sql');
 
         // dump specified database
-        $mysql->__construct(false, 'localhost', 3306, 'dizbdd', 'root', 'test', 'localhost');
+        $mysql->__construct(false, 'localhost', 3306, 'dizbdd', 'root', 'test', 'localhost', array());
         $this->assertEquals($mysql->getCommand(), 'mysqldump --host=localhost --port=3306 --user=root --password=test dizbdd > dizbdd.sql');
 
         // dump specified database
-        $mysql->__construct(false, 'somehost', 2222, 'somebdd', 'mysql', 'somepwd', 'localhost');
+        $mysql->__construct(false, 'somehost', 2222, 'somebdd', 'mysql', 'somepwd', 'localhost', array());
         $this->assertEquals($mysql->getCommand(), 'mysqldump --host=somehost --port=2222 --user=mysql --password=somepwd somebdd > somebdd.sql');
 
         // dump specified database with no auth
-        $mysql->__construct(false, 'somehost', 2222, 'somebdd', null, null, 'localhost');
+        $mysql->__construct(false, 'somehost', 2222, 'somebdd', null, null, 'localhost', array());
         $this->assertEquals($mysql->getCommand(), 'mysqldump  somebdd > somebdd.sql');
 
         // dump all databases with no auth
-        $mysql->__construct(true, 'somehost', 2222, 'somebdd', null, null, 'localhost');
+        $mysql->__construct(true, 'somehost', 2222, 'somebdd', null, null, 'localhost', array());
         $this->assertEquals($mysql->getCommand(), 'mysqldump  --all-databases > all-databases.sql');
     }
 

--- a/Tests/Databases/PostgreSQLTest.php
+++ b/Tests/Databases/PostgreSQLTest.php
@@ -19,17 +19,17 @@ class PostgreSQLTest extends AbstractTesting
         $postgresql = self::$kernel->getContainer()->get('dizda.cloudbackup.database.postgresql');
 
         // dump specified database
-        $postgresql->__construct('localhost', 5678, 'dizbdd', 'admin', 'test', 'testcase1');
+        $postgresql->__construct('localhost', 5678, 'dizbdd', 'admin', 'test', 'testcase1', array());
         $this->assertEquals($postgresql->getCommand(),
             'export PGPASSWORD="test" && pg_dump --username "admin" --host localhost --port 5678 --format plain --encoding UTF8 "dizbdd" > "dizbdd.sql"');
 
         // dump specified database
-        $postgresql->__construct('somehost', 2222, 'somebdd', 'postgres', 'somepwd', 'testcase2');
+        $postgresql->__construct('somehost', 2222, 'somebdd', 'postgres', 'somepwd', 'testcase2', array());
         $this->assertEquals($postgresql->getCommand(),
             'export PGPASSWORD="somepwd" && pg_dump --username "postgres" --host somehost --port 2222 --format plain --encoding UTF8 "somebdd" > "somebdd.sql"');
 
         // dump specified database with no auth
-        $postgresql->__construct('somehost', 2222, 'somebdd', null, null, 'testcase3');
+        $postgresql->__construct('somehost', 2222, 'somebdd', null, null, 'testcase3', array());
         $this->assertEquals($postgresql->getCommand(),
             'pg_dump --host somehost --port 2222 --format plain --encoding UTF8 "somebdd" > "somebdd.sql"');
 


### PR DESCRIPTION
Hi,

   I love this bundle, it's great for make backups, but I miss something important: Sometimes you want to make a backup with more information than the database. I mean, what is about user uploaded files? (for example). I propose you to add the posibility to select some folders to save in backup. This pull request contains the code to do it: You can add "folders" parameter with an array of folders to backup. Then, if you use --folders (or -F) option when you call "dizda:backup:start" task in the backup the folders will be added.

   What do you think?
