### PR TITLE
Started to write some logs & fixed the namespaces

### DIFF
--- a/Client/ClientChain.php
+++ b/Client/ClientChain.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Clients;
-
-use Dizda\CloudBackupBundle\Clients\ClientInterface;
+namespace Dizda\CloudBackupBundle\Client;
 
 /**
  * Class ClientChain

--- a/Client/ClientChain.php
+++ b/Client/ClientChain.php
@@ -10,7 +10,7 @@ namespace Dizda\CloudBackupBundle\Client;
 class ClientChain implements ClientInterface
 {
     /**
-     * @var array
+     * @var ClientInterface[] clients
      */
     protected $clients;
 
@@ -42,5 +42,15 @@ class ClientChain implements ClientInterface
         foreach ($this->clients as $client) {
             $client->upload($filePath);
         }
+    }
+
+    public function getName()
+    {
+        $names = array();
+        foreach ($this->clients as $client) {
+            $names[] = $client->getName();
+        }
+
+        return sprintf('ClientChain of %d (%s)', count($names), implode(', ', $names));
     }
 }

--- a/Client/ClientChain.php
+++ b/Client/ClientChain.php
@@ -10,16 +10,16 @@ namespace Dizda\CloudBackupBundle\Client;
 class ClientChain implements ClientInterface
 {
     /**
-     * @var ClientInterface[] clients
+     * @var ClientInterface[] children
      */
-    protected $clients;
+    protected $children;
 
     /**
      * @param array $clients
      */
     public function __construct(array $clients = array())
     {
-        $this->clients = $clients;
+        $this->children = $clients;
     }
 
     /**
@@ -29,7 +29,7 @@ class ClientChain implements ClientInterface
      */
     public function add(ClientInterface $client)
     {
-        $this->clients[] = $client;
+        $this->children[] = $client;
     }
 
     /**
@@ -39,16 +39,16 @@ class ClientChain implements ClientInterface
      */
     public function upload($filePath)
     {
-        foreach ($this->clients as $client) {
-            $client->upload($filePath);
+        foreach ($this->children as $child) {
+            $child->upload($filePath);
         }
     }
 
     public function getName()
     {
         $names = array();
-        foreach ($this->clients as $client) {
-            $names[] = $client->getName();
+        foreach ($this->children as $child) {
+            $names[] = $child->getName();
         }
 
         return sprintf('ClientChain of %d (%s)', count($names), implode(', ', $names));

--- a/Client/ClientInterface.php
+++ b/Client/ClientInterface.php
@@ -10,4 +10,11 @@ namespace Dizda\CloudBackupBundle\Client;
 interface ClientInterface
 {
     public function upload($archive);
+
+    /**
+     * The name of the client
+     *
+     * @return string
+     */
+    public function getName();
 }

--- a/Client/ClientInterface.php
+++ b/Client/ClientInterface.php
@@ -1,10 +1,10 @@
 <?php
-namespace Dizda\CloudBackupBundle\Clients;
+namespace Dizda\CloudBackupBundle\Client;
 
 /**
  * Class ClientInterface
  *
- * @package Dizda\CloudBackupBundle\Clients
+ * @package Dizda\CloudBackupBundle\Client
  * @author  Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 interface ClientInterface

--- a/Client/CloudAppClient.php
+++ b/Client/CloudAppClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Dizda\CloudBackupBundle\Client;
 
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/Client/CloudAppClient.php
+++ b/Client/CloudAppClient.php
@@ -1,5 +1,5 @@
 <?php
-namespace Dizda\CloudBackupBundle\Clients;
+namespace Dizda\CloudBackupBundle\Client;
 
 use Symfony\Component\Console\Output\ConsoleOutput;
 
@@ -9,7 +9,7 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * Class CloudAppClient
  *
- * @package Dizda\CloudBackupBundle\Clients
+ * @package Dizda\CloudBackupBundle\Client
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 class CloudAppClient implements ClientInterface

--- a/Client/CloudAppClient.php
+++ b/Client/CloudAppClient.php
@@ -48,4 +48,9 @@ class CloudAppClient implements ClientInterface
 //        }
 
     }
+
+    public function getName()
+    {
+        return 'CloudApp';
+    }
 }

--- a/Client/DropboxClient.php
+++ b/Client/DropboxClient.php
@@ -49,4 +49,8 @@ class DropboxClient implements ClientInterface
 //        }
     }
 
+    public function getName()
+    {
+        return 'Dropbox';
+    }
 }

--- a/Client/DropboxClient.php
+++ b/Client/DropboxClient.php
@@ -1,5 +1,5 @@
 <?php
-namespace Dizda\CloudBackupBundle\Clients;
+namespace Dizda\CloudBackupBundle\Client;
 
 use Symfony\Component\Console\Output\ConsoleOutput;
 
@@ -9,7 +9,7 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * Class DropboxClient
  *
- * @package Dizda\CloudBackupBundle\Clients
+ * @package Dizda\CloudBackupBundle\Client
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 class DropboxClient implements ClientInterface

--- a/Client/GaufretteClient.php
+++ b/Client/GaufretteClient.php
@@ -55,4 +55,8 @@ class GaufretteClient implements ClientInterface
         $this->filesystem = $filesystem;
     }
 
+    public function getName()
+    {
+        return 'Gaufrette';
+    }
 }

--- a/Client/GaufretteClient.php
+++ b/Client/GaufretteClient.php
@@ -1,5 +1,5 @@
 <?php
-namespace Dizda\CloudBackupBundle\Clients;
+namespace Dizda\CloudBackupBundle\Client;
 
 use Symfony\Component\Console\Output\ConsoleOutput;
 
@@ -10,7 +10,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * Class GaufretteClient
  * Client for Gaufrette drivers
  *
- * @package Dizda\CloudBackupBundle\Clients
+ * @package Dizda\CloudBackupBundle\Client
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 class GaufretteClient implements ClientInterface

--- a/Client/GoogleDriveClient.php
+++ b/Client/GoogleDriveClient.php
@@ -200,4 +200,9 @@ class GoogleDriveClient implements ClientInterface
             'uploadType' => 'media',
         ));
     }
+
+    public function getName()
+    {
+        return 'GoogleDrive';
+    }
 }

--- a/Client/GoogleDriveClient.php
+++ b/Client/GoogleDriveClient.php
@@ -1,5 +1,5 @@
 <?php
-namespace Dizda\CloudBackupBundle\Clients;
+namespace Dizda\CloudBackupBundle\Client;
 
 use Happyr\GoogleSiteAuthenticatorBundle\Service\ClientProvider;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -8,7 +8,7 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * Class GoogleDriveClient
  *
- * @package Dizda\CloudBackupBundle\Clients
+ * @package Dizda\CloudBackupBundle\Client
  * @author  Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class GoogleDriveClient implements ClientInterface

--- a/Command/BackupCommand.php
+++ b/Command/BackupCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dizda\CloudBackupBundle\Command;
 
-use Dizda\CloudBackupBundle\Splitters\ZipSplitSplitter;
+use Dizda\CloudBackupBundle\Splitter\ZipSplitSplitter;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Database/BaseDatabase.php
+++ b/Database/BaseDatabase.php
@@ -1,5 +1,5 @@
 <?php
-namespace Dizda\CloudBackupBundle\Databases;
+namespace Dizda\CloudBackupBundle\Database;
 
 use Monolog\Logger;
 use Symfony\Component\Filesystem\Filesystem;
@@ -8,7 +8,7 @@ use Symfony\Component\Process\Process;
 /**
  * Class BaseDatabase
  *
- * @package Dizda\CloudBackupBundle\Databases
+ * @package Dizda\CloudBackupBundle\Database
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 abstract class BaseDatabase implements DatabaseInterface

--- a/Database/DatabaseChain.php
+++ b/Database/DatabaseChain.php
@@ -12,7 +12,7 @@ use Dizda\CloudBackupBundle\Database\DatabaseInterface;
 class DatabaseChain implements DatabaseInterface
 {
     /**
-     * @var array
+     * @var DatabaseInterface[] databases
      */
     protected $databases;
 
@@ -42,5 +42,15 @@ class DatabaseChain implements DatabaseInterface
         foreach ($this->databases as $database) {
             $database->dump();
         }
+    }
+
+    public function getName()
+    {
+        $names = array();
+        foreach ($this->databases as $database) {
+            $names[] = $database->getName();
+        }
+
+        return sprintf('DatabaseChain of %d (%s)', count($names), implode(', ', $names));
     }
 }

--- a/Database/DatabaseChain.php
+++ b/Database/DatabaseChain.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Databases;
+namespace Dizda\CloudBackupBundle\Database;
 
-use Dizda\CloudBackupBundle\Databases\DatabaseInterface;
+use Dizda\CloudBackupBundle\Database\DatabaseInterface;
 
 /**
  * Class DatabaseChain

--- a/Database/DatabaseChain.php
+++ b/Database/DatabaseChain.php
@@ -12,16 +12,17 @@ use Dizda\CloudBackupBundle\Database\DatabaseInterface;
 class DatabaseChain implements DatabaseInterface
 {
     /**
-     * @var DatabaseInterface[] databases
+     * @var DatabaseInterface[] links
+     *
      */
-    protected $databases;
+    protected $children;
 
     /**
      * @param DatabaseInterface[] $databases
      */
     public function __construct(array $databases = array())
     {
-        $this->databases = $databases;
+        $this->children = $databases;
     }
 
     /**
@@ -31,7 +32,7 @@ class DatabaseChain implements DatabaseInterface
      */
     public function add(DatabaseInterface $database)
     {
-        $this->databases[] = $database;
+        $this->children[] = $database;
     }
 
     /**
@@ -39,16 +40,16 @@ class DatabaseChain implements DatabaseInterface
      */
     public function dump()
     {
-        foreach ($this->databases as $database) {
-            $database->dump();
+        foreach ($this->children as $child) {
+            $child->dump();
         }
     }
 
     public function getName()
     {
         $names = array();
-        foreach ($this->databases as $database) {
-            $names[] = $database->getName();
+        foreach ($this->children as $child) {
+            $names[] = $child->getName();
         }
 
         return sprintf('DatabaseChain of %d (%s)', count($names), implode(', ', $names));

--- a/Database/DatabaseInterface.php
+++ b/Database/DatabaseInterface.php
@@ -18,4 +18,10 @@ interface DatabaseInterface
      */
     public function dump();
 
+    /**
+     * The name of the database
+     *
+     * @return string
+     */
+    public function getName();
 }

--- a/Database/DatabaseInterface.php
+++ b/Database/DatabaseInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Databases;
+namespace Dizda\CloudBackupBundle\Database;
 
 /**
  * Interface DatabaseInterface
  *
- * @package Dizda\CloudBackupBundle\Databases
+ * @package Dizda\CloudBackupBundle\Database
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 

--- a/Database/MongoDB.php
+++ b/Database/MongoDB.php
@@ -1,10 +1,10 @@
 <?php
-namespace Dizda\CloudBackupBundle\Databases;
+namespace Dizda\CloudBackupBundle\Database;
 
 /**
  * Class MongoDB
  *
- * @package Dizda\CloudBackupBundle\Databases
+ * @package Dizda\CloudBackupBundle\Database
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 class MongoDB extends BaseDatabase

--- a/Database/MongoDB.php
+++ b/Database/MongoDB.php
@@ -68,4 +68,9 @@ class MongoDB extends BaseDatabase
             $this->database,
             $this->dataPath);
     }
+
+    public function getName()
+    {
+        return 'MongoDB';
+    }
 }

--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -70,4 +70,8 @@ class MySQL extends BaseDatabase
             $this->dataPath . $this->fileName);
     }
 
+    public function getName()
+    {
+        return 'MySQL';
+    }
 }

--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -1,10 +1,10 @@
 <?php
-namespace Dizda\CloudBackupBundle\Databases;
+namespace Dizda\CloudBackupBundle\Database;
 
 /**
  * Class MySQL
  *
- * @package Dizda\CloudBackupBundle\Databases
+ * @package Dizda\CloudBackupBundle\Database
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 class MySQL extends BaseDatabase

--- a/Database/PostgreSQL.php
+++ b/Database/PostgreSQL.php
@@ -1,10 +1,10 @@
 <?php
-namespace Dizda\CloudBackupBundle\Databases;
+namespace Dizda\CloudBackupBundle\Database;
 
 /**
  * Class MySQL
  *
- * @package Dizda\CloudBackupBundle\Databases
+ * @package Dizda\CloudBackupBundle\Database
  * @author  István Manzuk <istvan.manzuk@gmail.com>
  */
 class PostgreSQL extends BaseDatabase

--- a/Database/PostgreSQL.php
+++ b/Database/PostgreSQL.php
@@ -68,4 +68,8 @@ class PostgreSQL extends BaseDatabase
             $this->dataPath . $this->fileName);
     }
 
+    public function getName()
+    {
+        return 'PostgreSQL';
+    }
 }

--- a/DependencyInjection/Compiler/TaggedServicesPass.php
+++ b/DependencyInjection/Compiler/TaggedServicesPass.php
@@ -33,7 +33,7 @@ class TaggedServicesPass implements CompilerPassInterface
         $databases = $container->findTaggedServiceIds('dizda.cloudbackup.database');
         $dbEnabled = $container->getParameter('dizda_cloud_backup.databases');
 
-        $chainDefinition = $container->getDefinition('dizda.cloudbackup.chain.database');
+        $databaseManager = $container->getDefinition('dizda.cloudbackup.manager.database');
 
         foreach ($databases as $serviceId => $tags) {
             // Get the name of the database
@@ -45,7 +45,7 @@ class TaggedServicesPass implements CompilerPassInterface
             }
 
             // if the database is activated in the configuration file, we add it to the DatabaseChain
-            $chainDefinition->addMethodCall('add', array(new Reference($serviceId)));
+            $databaseManager->addMethodCall('add', array(new Reference($serviceId)));
         }
     }
 
@@ -57,7 +57,7 @@ class TaggedServicesPass implements CompilerPassInterface
         $clients        = $container->findTaggedServiceIds('dizda.cloudbackup.client');
         $clientsEnabled = $container->getParameter('dizda_cloud_backup.cloud_storages');
 
-        $chainDefinition = $container->getDefinition('dizda.cloudbackup.chain.client');
+        $clientManager = $container->getDefinition('dizda.cloudbackup.manager.client');
 
         foreach ($clients as $serviceId => $tags) {
             // Get the name of the database
@@ -69,7 +69,7 @@ class TaggedServicesPass implements CompilerPassInterface
             }
 
             // if the client is activated in the configuration file, we add it to the ClientChain
-            $chainDefinition->addMethodCall('add', array(new Reference($serviceId)));
+            $clientManager->addMethodCall('add', array(new Reference($serviceId)));
         }
 
         // If gaufrette is set, assign automatically the specified filesystem as the cloud client

--- a/Manager/BackupManager.php
+++ b/Manager/BackupManager.php
@@ -2,10 +2,10 @@
 
 namespace Dizda\CloudBackupBundle\Manager;
 
-use Dizda\CloudBackupBundle\Clients\ClientChain;
-use Dizda\CloudBackupBundle\Clients\ClientInterface;
-use Dizda\CloudBackupBundle\Databases\DatabaseChain;
-use Dizda\CloudBackupBundle\Databases\DatabaseInterface;
+use Dizda\CloudBackupBundle\Client\ClientChain;
+use Dizda\CloudBackupBundle\Client\ClientInterface;
+use Dizda\CloudBackupBundle\Database\DatabaseChain;
+use Dizda\CloudBackupBundle\Database\DatabaseInterface;
 use Monolog\Logger;
 
 class BackupManager
@@ -16,12 +16,12 @@ class BackupManager
     private $logger;
 
     /**
-     * @var \Dizda\CloudBackupBundle\Databases\DatabaseChain
+     * @var \Dizda\CloudBackupBundle\Database\DatabaseChain
      */
     private $database;
 
     /**
-     * @var \Dizda\CloudBackupBundle\Clients\ClientChain
+     * @var \Dizda\CloudBackupBundle\Client\ClientChain
      */
     private $client;
 

--- a/Manager/BackupManager.php
+++ b/Manager/BackupManager.php
@@ -53,24 +53,29 @@ class BackupManager
     {
         try {
             // Dump all databases
+            $this->logger->info('[Dizda Backup] Starting to dump the database.');
             $this->database->dump();
 
             // Backup folders if specified
+            $this->logger->info('[Dizda Backup] Copying folders.');
             $this->processor->copyFolders();
 
             // Compress everything
+            $this->logger->info('[Dizda Backup] Compressing to archive.');
             $this->processor->compress();
 
             var_dump($this->processor->getArchivePath());
 
             // Transfer with all clients
+            $this->logger->info('[Dizda Backup] Uploading archive.');
             $this->client->upload($this->processor->getArchivePath());
 
+            $this->logger->info('[Dizda Backup] Cleaning up after us.');
             $this->processor->cleanUp();
 
         } catch (\Exception $e) {
             // write log
-            $this->logger->critical('Error while DizdaBackupManager was running.'."\n".$e);
+            $this->logger->critical('[Dizda Backup] Unexpected exception.', array('exception'=>$e));
 
             return false;
         }

--- a/Manager/BackupManager.php
+++ b/Manager/BackupManager.php
@@ -53,7 +53,7 @@ class BackupManager
     {
         try {
             // Dump all databases
-            $this->logger->info('[Dizda Backup] Starting to dump the database.');
+            $this->logger->info('[Dizda Backup] Starting to dump the database.', array('databases'=>$this->database->getName()));
             $this->database->dump();
 
             // Backup folders if specified
@@ -61,13 +61,13 @@ class BackupManager
             $this->processor->copyFolders();
 
             // Compress everything
-            $this->logger->info('[Dizda Backup] Compressing to archive.');
+            $this->logger->info('[Dizda Backup] Compressing to archive.', array('processor'=>$this->processor->getName()));
             $this->processor->compress();
 
             var_dump($this->processor->getArchivePath());
 
             // Transfer with all clients
-            $this->logger->info('[Dizda Backup] Uploading archive.');
+            $this->logger->info('[Dizda Backup] Uploading archive.', array('clients'=>$this->client->getName()));
             $this->client->upload($this->processor->getArchivePath());
 
             $this->logger->info('[Dizda Backup] Cleaning up after us.');

--- a/Manager/BackupManager.php
+++ b/Manager/BackupManager.php
@@ -2,9 +2,8 @@
 
 namespace Dizda\CloudBackupBundle\Manager;
 
-use Dizda\CloudBackupBundle\Client\ClientChain;
+
 use Dizda\CloudBackupBundle\Client\ClientInterface;
-use Dizda\CloudBackupBundle\Database\DatabaseChain;
 use Dizda\CloudBackupBundle\Database\DatabaseInterface;
 use Monolog\Logger;
 
@@ -16,14 +15,14 @@ class BackupManager
     private $logger;
 
     /**
-     * @var \Dizda\CloudBackupBundle\Database\DatabaseChain
+     * @var \Dizda\CloudBackupBundle\Manager\DatabaseManager
      */
-    private $database;
+    private $dbm;
 
     /**
-     * @var \Dizda\CloudBackupBundle\Client\ClientChain
+     * @var \Dizda\CloudBackupBundle\Manager\ClientManager
      */
-    private $client;
+    private $cm;
 
     /**
      * @var \Dizda\CloudBackupBundle\Manager\ProcessorManager
@@ -32,15 +31,15 @@ class BackupManager
 
     /**
      * @param Logger $logger
-     * @param DatabaseInterface $database
-     * @param ClientInterface $client
+     * @param DatabaseManager $database
+     * @param ClientManager $client
      * @param ProcessorManager $processor
      */
-    public function __construct(Logger $logger, DatabaseInterface $database, ClientInterface $client, ProcessorManager $processor)
+    public function __construct(Logger $logger, DatabaseManager $database, ClientManager $client, ProcessorManager $processor)
     {
         $this->logger    = $logger;
-        $this->database  = $database;
-        $this->client    = $client;
+        $this->dbm       = $database;
+        $this->cm        = $client;
         $this->processor = $processor;
     }
 
@@ -53,8 +52,8 @@ class BackupManager
     {
         try {
             // Dump all databases
-            $this->logger->info('[Dizda Backup] Starting to dump the database.', array('databases'=>$this->database->getName()));
-            $this->database->dump();
+            $this->logger->info('[Dizda Backup] Starting to dump the database.', array('databases'=>$this->dbm->getName()));
+            $this->dbm->dump();
 
             // Backup folders if specified
             $this->logger->info('[Dizda Backup] Copying folders.');
@@ -67,8 +66,8 @@ class BackupManager
             var_dump($this->processor->getArchivePath());
 
             // Transfer with all clients
-            $this->logger->info('[Dizda Backup] Uploading archive.', array('clients'=>$this->client->getName()));
-            $this->client->upload($this->processor->getArchivePath());
+            $this->logger->info('[Dizda Backup] Uploading archive.', array('clients'=>$this->cm->getName()));
+            $this->cm->upload($this->processor->getArchivePath());
 
             $this->logger->info('[Dizda Backup] Cleaning up after us.');
             $this->processor->cleanUp();

--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Client;
+namespace Dizda\CloudBackupBundle\Manager;
 
 /**
  * Class ClientChain
  *
  * @author Jonathan Dizdarevic <dizda@dizda.fr>
  */
-class ClientChain implements ClientInterface
+class ClientManager
 {
     /**
      * @var ClientInterface[] children

--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -2,6 +2,9 @@
 
 namespace Dizda\CloudBackupBundle\Manager;
 
+use Dizda\CloudBackupBundle\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+
 /**
  * Class ClientChain
  *
@@ -15,10 +18,17 @@ class ClientManager
     protected $children;
 
     /**
-     * @param array $clients
+     * @var \Psr\Log\LoggerInterface logger
      */
-    public function __construct(array $clients = array())
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param ClientInterface[] $clients
+     */
+    public function __construct(LoggerInterface $logger, array $clients = array())
     {
+        $this->logger = $logger;
         $this->children = $clients;
     }
 
@@ -40,17 +50,8 @@ class ClientManager
     public function upload($filePath)
     {
         foreach ($this->children as $child) {
+            $this->logger->info(sprintf('[Dizda Backup] Uploading to %s', $child->getName()));
             $child->upload($filePath);
         }
-    }
-
-    public function getName()
-    {
-        $names = array();
-        foreach ($this->children as $child) {
-            $names[] = $child->getName();
-        }
-
-        return sprintf('ClientChain of %d (%s)', count($names), implode(', ', $names));
     }
 }

--- a/Manager/DatabaseManager.php
+++ b/Manager/DatabaseManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Database;
+namespace Dizda\CloudBackupBundle\Manager;
 
 use Dizda\CloudBackupBundle\Database\DatabaseInterface;
 
@@ -9,7 +9,7 @@ use Dizda\CloudBackupBundle\Database\DatabaseInterface;
  *
  * @author Jonathan Dizdarevic <dizda@dizda.fr>
  */
-class DatabaseChain implements DatabaseInterface
+class DatabaseManager
 {
     /**
      * @var DatabaseInterface[] links

--- a/Manager/DatabaseManager.php
+++ b/Manager/DatabaseManager.php
@@ -3,6 +3,7 @@
 namespace Dizda\CloudBackupBundle\Manager;
 
 use Dizda\CloudBackupBundle\Database\DatabaseInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class DatabaseChain
@@ -18,10 +19,17 @@ class DatabaseManager
     protected $children;
 
     /**
+     * @var \Psr\Log\LoggerInterface logger
+     */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
      * @param DatabaseInterface[] $databases
      */
-    public function __construct(array $databases = array())
+    public function __construct(LoggerInterface $logger, array $databases = array())
     {
+        $this->logger = $logger;
         $this->children = $databases;
     }
 
@@ -41,17 +49,8 @@ class DatabaseManager
     public function dump()
     {
         foreach ($this->children as $child) {
+            $this->logger->info(sprintf('[Dizda Backup] Dumping %s database', $child->getName()));
             $child->dump();
         }
-    }
-
-    public function getName()
-    {
-        $names = array();
-        foreach ($this->children as $child) {
-            $names[] = $child->getName();
-        }
-
-        return sprintf('DatabaseChain of %d (%s)', count($names), implode(', ', $names));
     }
 }

--- a/Manager/ProcessorManager.php
+++ b/Manager/ProcessorManager.php
@@ -178,4 +178,9 @@ class ProcessorManager
         var_dump($splitFiles);
         var_dump('----split');
     }
+
+    public function getName()
+    {
+        return $this->processor->getName();
+    }
 }

--- a/Manager/ProcessorManager.php
+++ b/Manager/ProcessorManager.php
@@ -2,8 +2,8 @@
 
 namespace Dizda\CloudBackupBundle\Manager;
 
-use Dizda\CloudBackupBundle\Processors\ProcessorInterface;
-use Dizda\CloudBackupBundle\Splitters\ZipSplitSplitter;
+use Dizda\CloudBackupBundle\Processor\ProcessorInterface;
+use Dizda\CloudBackupBundle\Splitter\ZipSplitSplitter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
@@ -15,7 +15,7 @@ use Symfony\Component\Process\Process;
 class ProcessorManager
 {
     /**
-     * @var \Dizda\CloudBackupBundle\Processors\ProcessorInterface processor
+     * @var \Dizda\CloudBackupBundle\Processor\ProcessorInterface processor
      */
     protected $processor;
 
@@ -82,7 +82,7 @@ class ProcessorManager
     }
 
     /**
-     * @param \Dizda\CloudBackupBundle\Processors\ProcessorInterface $processor
+     * @param \Dizda\CloudBackupBundle\Processor\ProcessorInterface $processor
      *
      * @return $this
      */

--- a/Processor/BaseProcessor.php
+++ b/Processor/BaseProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Processors;
+namespace Dizda\CloudBackupBundle\Processor;
 
 /**
  * @author Tobias Nyholm

--- a/Processor/ProcessorInterface.php
+++ b/Processor/ProcessorInterface.php
@@ -1,10 +1,10 @@
 <?php
-namespace Dizda\CloudBackupBundle\Processors;
+namespace Dizda\CloudBackupBundle\Processor;
 
 /**
  * Interface ProcessorInterface
  *
- * @package Dizda\CloudBackupBundle\Processors
+ * @package Dizda\CloudBackupBundle\Processor
  * @author  Jonathan Dizdarevic <dizda@dizda.fr>
  */
 interface ProcessorInterface

--- a/Processor/ProcessorInterface.php
+++ b/Processor/ProcessorInterface.php
@@ -25,4 +25,11 @@ interface ProcessorInterface
      * @return string
      */
     public function getExtension();
+
+    /**
+     * The name of the processor
+     *
+     * @return string
+     */
+    public function getName();
 }

--- a/Processor/SevenZipProcessor.php
+++ b/Processor/SevenZipProcessor.php
@@ -35,4 +35,9 @@ class SevenZipProcessor extends BaseProcessor implements ProcessorInterface
 
         return sprintf('cd %s && 7z a %s %s', $basePath, implode(' ', $params), $archivePath);
     }
+
+    public function getName()
+    {
+        return 'SevenZip';
+    }
 }

--- a/Processor/SevenZipProcessor.php
+++ b/Processor/SevenZipProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Processors;
+namespace Dizda\CloudBackupBundle\Processor;
 
 class SevenZipProcessor extends BaseProcessor implements ProcessorInterface
 {

--- a/Processor/TarProcessor.php
+++ b/Processor/TarProcessor.php
@@ -31,4 +31,9 @@ class TarProcessor extends BaseProcessor implements ProcessorInterface
             $archivePath
         );
     }
+
+    public function getName()
+    {
+        return 'Tar';
+    }
 }

--- a/Processor/TarProcessor.php
+++ b/Processor/TarProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Processors;
+namespace Dizda\CloudBackupBundle\Processor;
 
 class TarProcessor extends BaseProcessor implements ProcessorInterface
 {

--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Processors;
+namespace Dizda\CloudBackupBundle\Processor;
 
 class ZipProcessor extends BaseProcessor implements ProcessorInterface
 {

--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -30,4 +30,9 @@ class ZipProcessor extends BaseProcessor implements ProcessorInterface
 
         return sprintf('cd %s && zip %s %s .', $basePath, implode(' ', $params), $archivePath);
     }
+
+    public function getName()
+    {
+        return 'Zip';
+    }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,9 +1,13 @@
 services:
     dizda.cloudbackup.manager.database:
         class: Dizda\CloudBackupBundle\Manager\DatabaseManager
+        arguments:
+          - @logger
 
     dizda.cloudbackup.manager.client:
         class: Dizda\CloudBackupBundle\Manager\ClientManager
+        arguments:
+          - @logger
 
     dizda.cloudbackup.client.cloudapp:
         class: Dizda\CloudBackupBundle\Client\CloudAppClient

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,38 +1,38 @@
 services:
     dizda.cloudbackup.chain.database:
-        class: Dizda\CloudBackupBundle\Databases\DatabaseChain
+        class: Dizda\CloudBackupBundle\Database\DatabaseChain
 
     dizda.cloudbackup.chain.client:
-        class: Dizda\CloudBackupBundle\Clients\ClientChain
+        class: Dizda\CloudBackupBundle\Client\ClientChain
 
     dizda.cloudbackup.client.cloudapp:
-        class: Dizda\CloudBackupBundle\Clients\CloudAppClient
+        class: Dizda\CloudBackupBundle\Client\CloudAppClient
         arguments:
             - %dizda_cloud_backup.cloud_storages%
         tags:
             -  { name: dizda.cloudbackup.client }
 
     dizda.cloudbackup.client.dropbox:
-        class: Dizda\CloudBackupBundle\Clients\DropboxClient
+        class: Dizda\CloudBackupBundle\Client\DropboxClient
         arguments:
             - %dizda_cloud_backup.cloud_storages%
         tags:
             -  { name: dizda.cloudbackup.client }
 
     dizda.cloudbackup.client.google_drive:
-        class: Dizda\CloudBackupBundle\Clients\GoogleDriveClient
+        class: Dizda\CloudBackupBundle\Client\GoogleDriveClient
         public: false
         arguments: [~, ~, ~]
         tags:
             -  { name: dizda.cloudbackup.client }
 
     dizda.cloudbackup.client.gaufrette:
-        class: Dizda\CloudBackupBundle\Clients\GaufretteClient
+        class: Dizda\CloudBackupBundle\Client\GaufretteClient
         tags:
             -  { name: dizda.cloudbackup.client }
 
     dizda.cloudbackup.database.mongodb:
-        class: Dizda\CloudBackupBundle\Databases\MongoDB
+        class: Dizda\CloudBackupBundle\Database\MongoDB
         arguments:
             - %dizda_cloud_backup.databases%
             - %dizda_cloud_backup.output_folder%
@@ -43,7 +43,7 @@ services:
             -  { name: dizda.cloudbackup.database }
 
     dizda.cloudbackup.database.mysql:
-        class: Dizda\CloudBackupBundle\Databases\MySQL
+        class: Dizda\CloudBackupBundle\Database\MySQL
         arguments:
             - %dizda_cloud_backup.databases%
             - %dizda_cloud_backup.output_folder%
@@ -54,7 +54,7 @@ services:
             -  { name: dizda.cloudbackup.database }
 
     dizda.cloudbackup.database.postgresql:
-        class: Dizda\CloudBackupBundle\Databases\PostgreSQL
+        class: Dizda\CloudBackupBundle\Database\PostgreSQL
         arguments:
             - %dizda_cloud_backup.databases%
             - %dizda_cloud_backup.output_folder%
@@ -65,17 +65,17 @@ services:
             -  { name: dizda.cloudbackup.database }
 
     dizda.cloudbackup.processor.tar:
-        class: Dizda\CloudBackupBundle\Processors\TarProcessor
+        class: Dizda\CloudBackupBundle\Processor\TarProcessor
         tags:
             -  { name: dizda.cloudbackup.processor }
 
     dizda.cloudbackup.processor.zip:
-        class: Dizda\CloudBackupBundle\Processors\ZipProcessor
+        class: Dizda\CloudBackupBundle\Processor\ZipProcessor
         tags:
             -  { name: dizda.cloudbackup.processor }
 
     dizda.cloudbackup.processor.7z:
-        class: Dizda\CloudBackupBundle\Processors\SevenZipProcessor
+        class: Dizda\CloudBackupBundle\Processor\SevenZipProcessor
         tags:
             -  { name: dizda.cloudbackup.processor }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,9 +1,9 @@
 services:
-    dizda.cloudbackup.chain.database:
-        class: Dizda\CloudBackupBundle\Database\DatabaseChain
+    dizda.cloudbackup.manager.database:
+        class: Dizda\CloudBackupBundle\Manager\DatabaseManager
 
-    dizda.cloudbackup.chain.client:
-        class: Dizda\CloudBackupBundle\Client\ClientChain
+    dizda.cloudbackup.manager.client:
+        class: Dizda\CloudBackupBundle\Manager\ClientManager
 
     dizda.cloudbackup.client.cloudapp:
         class: Dizda\CloudBackupBundle\Client\CloudAppClient
@@ -84,8 +84,8 @@ services:
         class: Dizda\CloudBackupBundle\Manager\BackupManager
         arguments:
             - @logger
-            - @dizda.cloudbackup.chain.database
-            - @dizda.cloudbackup.chain.client
+            - @dizda.cloudbackup.manager.database
+            - @dizda.cloudbackup.manager.client
             - @dizda.cloudbackup.manager.processor
 
     dizda.cloudbackup.manager.processor:

--- a/Splitter/BaseSplitter.php
+++ b/Splitter/BaseSplitter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Splitters;
+namespace Dizda\CloudBackupBundle\Splitter;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Finder\Finder;
 
 /**
  * Interface SplittersInterface
  *
- * @package Dizda\CloudBackupBundle\Splitters
+ * @package Dizda\CloudBackupBundle\Splitter
  * @author Nick Doulgeridis
  */
 abstract class BaseSplitter

--- a/Splitter/ZipSplitSplitter.php
+++ b/Splitter/ZipSplitSplitter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dizda\CloudBackupBundle\Splitters;
+namespace Dizda\CloudBackupBundle\Splitter;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\HttpFoundation\File\File;
@@ -9,7 +9,7 @@ use Symfony\Component\Process\Process;
 /**
  * Class ZipSplitSplitter
  *
- * @package Dizda\CloudBackupBundle\Splitters
+ * @package Dizda\CloudBackupBundle\Splitter
  * @author Nick Doulgeridis
  */
 class ZipSplitSplitter extends BaseSplitter

--- a/Tests/Clients/GoogleDriveClientTest.php
+++ b/Tests/Clients/GoogleDriveClientTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Clients;
 
-use Dizda\CloudBackupBundle\Clients\GoogleDriveClient;
+use Dizda\CloudBackupBundle\Client\GoogleDriveClient;
 
 /**
  * @author Tobias Nyholm
@@ -26,7 +26,7 @@ class GoogleDriveClientTest extends \PHPUnit_Framework_TestCase
             ->method('setParents')
             ->with($this->equalTo(array($driveParent)));
 
-        $drive=$this->getMockBuilder('Dizda\CloudBackupBundle\Clients\GoogleDriveClient')
+        $drive=$this->getMockBuilder('Dizda\CloudBackupBundle\Client\GoogleDriveClient')
             ->setConstructorArgs(array($clientProvider, 'foobar', '/foo/bar'))
             ->setMethods(array('output', 'getDriveService', 'getDriveFile', 'getMimeType', 'getParentFolder', 'getFileContents'))
             ->getMock();

--- a/Tests/Databases/MongoDBTest.php
+++ b/Tests/Databases/MongoDBTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Databases;
 
-use Dizda\CloudBackupBundle\Databases\MongoDB;
+use Dizda\CloudBackupBundle\Database\MongoDB;
 use Dizda\CloudBackupBundle\Tests\AbstractTesting;
 
 /**

--- a/Tests/Databases/MySQLTest.php
+++ b/Tests/Databases/MySQLTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Databases;
 
-use Dizda\CloudBackupBundle\Databases\MySQL;
+use Dizda\CloudBackupBundle\Database\MySQL;
 use Dizda\CloudBackupBundle\Tests\AbstractTesting;
 
 /**

--- a/Tests/Databases/PostgreSQLTest.php
+++ b/Tests/Databases/PostgreSQLTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Databases;
 
-use Dizda\CloudBackupBundle\Databases\PostgreSQL;
+use Dizda\CloudBackupBundle\Database\PostgreSQL;
 use Dizda\CloudBackupBundle\Tests\AbstractTesting;
 
 /**

--- a/Tests/Processors/SevenZipTest.php
+++ b/Tests/Processors/SevenZipTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Processors;
 
-use Dizda\CloudBackupBundle\Processors\SevenZipProcessor;
+use Dizda\CloudBackupBundle\Processor\SevenZipProcessor;
 use Dizda\CloudBackupBundle\Tests\AbstractTesting;
 
 /**

--- a/Tests/Processors/TarTest.php
+++ b/Tests/Processors/TarTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Processors;
 
-use Dizda\CloudBackupBundle\Processors\TarProcessor;
+use Dizda\CloudBackupBundle\Processor\TarProcessor;
 use Dizda\CloudBackupBundle\Tests\AbstractTesting;
 
 /**

--- a/Tests/Processors/ZipTest.php
+++ b/Tests/Processors/ZipTest.php
@@ -2,7 +2,7 @@
 
 namespace Dizda\CloudBackupBundle\Tests\Processors;
 
-use Dizda\CloudBackupBundle\Processors\ZipProcessor;
+use Dizda\CloudBackupBundle\Processor\ZipProcessor;
 use Dizda\CloudBackupBundle\Tests\AbstractTesting;
 
 /**

--- a/Tests/Splitters/ZipSplitTest.php
+++ b/Tests/Splitters/ZipSplitTest.php
@@ -1,8 +1,8 @@
 <?php
 
 namespace Dizda\CloudBackupBundle\Tests\Splitters;
-use Dizda\CloudBackupBundle\Splitters\ZipSplitSplitter;
 
+use Dizda\CloudBackupBundle\Splitter\ZipSplitSplitter;
 
 /**
  * @author Nick Doulgeridis


### PR DESCRIPTION
The namespaces should be in singular. 

### Logs

How should we do with the logs? Either we let each client/database worker be in charge of writing logs. Or we may introduce `[Client|Database|Processor]Interface::getName()` and have the `BackupManager` handle writing the logs. 

Ref #51 