### PR TITLE
Removed the ConsoleOutput from the clients

### DIFF
--- a/Client/CloudAppClient.php
+++ b/Client/CloudAppClient.php
@@ -12,7 +12,6 @@ use CloudApp\API as CloudApp;
  */
 class CloudAppClient implements ClientInterface
 {
-    private $output;
     private $user;
     private $password;
 
@@ -21,7 +20,6 @@ class CloudAppClient implements ClientInterface
      */
     public function __construct($params)
     {
-        $this->output     = new ConsoleOutput();
         $this->user       = $params['user'];
         $this->password   = $params['password'];
     }

--- a/Client/DropboxClient.php
+++ b/Client/DropboxClient.php
@@ -11,7 +11,6 @@ use DropboxUploader;
  */
 class DropboxClient implements ClientInterface
 {
-    private $output;
     private $user;
     private $password;
     private $remotePath;
@@ -21,7 +20,6 @@ class DropboxClient implements ClientInterface
      */
     public function __construct($params)
     {
-        $this->output     = new ConsoleOutput();
         $params           = $params['dropbox'];
         $this->user       = $params['user'];
         $this->password   = $params['password'];

--- a/Client/GaufretteClient.php
+++ b/Client/GaufretteClient.php
@@ -12,16 +12,7 @@ use Gaufrette\Filesystem;
  */
 class GaufretteClient implements ClientInterface
 {
-    private $output;
     private $filesystem;
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->output     = new ConsoleOutput();
-    }
 
     /**
      * {@inheritdoc}

--- a/Client/GoogleDriveClient.php
+++ b/Client/GoogleDriveClient.php
@@ -2,7 +2,6 @@
 namespace Dizda\CloudBackupBundle\Client;
 
 use Happyr\GoogleSiteAuthenticatorBundle\Service\ClientProvider;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
  * Class GoogleDriveClient.
@@ -11,11 +10,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  */
 class GoogleDriveClient implements ClientInterface
 {
-    /**
-     * @var ConsoleOutput output
-     */
-    protected $output;
-
     /**
      * @var \Happyr\GoogleSiteAuthenticatorBundle\Service\ClientProvider clientProvider
      */
@@ -33,7 +27,6 @@ class GoogleDriveClient implements ClientInterface
      */
     public function __construct(ClientProvider $clientProvider, $tokenName, $remotePath)
     {
-        $this->output = new ConsoleOutput();
         $this->clientProvider = $clientProvider;
         $this->tokenName = $tokenName;
         $this->remotePath = $remotePath;
@@ -46,7 +39,6 @@ class GoogleDriveClient implements ClientInterface
     {
         $service = $this->getDriveService();
         $this->handleUpload($service, $archive);
-        $this->output->writeln('<info>OK</info>');
     }
 
     /**
@@ -72,7 +64,7 @@ class GoogleDriveClient implements ClientInterface
      */
     protected function getParentFolder(\Google_Service_Drive $service)
     {
-        $parts = explode('/', ltrim($this->remotePath, '/'));
+        $parts = explode('/', trim($this->remotePath, '/'));
         $folderId = null;
         foreach ($parts as $name) {
             $q = 'mimeType="application/vnd.google-apps.folder" and title contains "'.$name.'"';
@@ -125,19 +117,6 @@ class GoogleDriveClient implements ClientInterface
         $file->setTitle($filename);
 
         return $file;
-    }
-
-    /**
-     * @param $message
-     * @param bool $newLine
-     */
-    protected function output($message, $newLine = true)
-    {
-        if ($newLine) {
-            $this->output->writeln($message);
-        } else {
-            $this->output->write($message);
-        }
     }
 
     /**

--- a/Manager/BackupManager.php
+++ b/Manager/BackupManager.php
@@ -33,11 +33,15 @@ class BackupManager
      * @param ClientManager    $client
      * @param ProcessorManager $processor
      */
-    public function __construct(LoggerInterface $logger, DatabaseManager $database, ClientManager $client, ProcessorManager $processor)
-    {
-        $this->logger    = $logger;
-        $this->dbm       = $database;
-        $this->cm        = $client;
+    public function __construct(
+        LoggerInterface $logger,
+        DatabaseManager $database,
+        ClientManager $client,
+        ProcessorManager $processor
+    ) {
+        $this->logger = $logger;
+        $this->dbm = $database;
+        $this->cm = $client;
         $this->processor = $processor;
     }
 
@@ -48,6 +52,7 @@ class BackupManager
      */
     public function execute()
     {
+        $successful = true;
         try {
             // Dump all databases
             $this->dbm->dump();
@@ -62,25 +67,23 @@ class BackupManager
 
             // Transfer with all clients
             $this->cm->upload($this->processor->getArchivePath());
-
         } catch (\Exception $e) {
             // Write log
             $this->logger->critical('[dizda-backup] Unexpected exception.', array('exception' => $e));
 
-            return false;
-        } finally {
-            // If we catch an exception or not, we would still like to try cleaning up after us
-            $this->logger->info('[dizda-backup] Cleaning up after us.');
-
-            try {
-                $this->processor->cleanUp();
-            } catch (IOException $e) {
-                $this->logger->error('[dizda-backup] Cleaning up failed.');
-
-                return false;
-            }
+            $successful = false;
         }
 
-        return true;
+        try {
+            // If we catch an exception or not, we would still like to try cleaning up after us
+            $this->logger->info('[dizda-backup] Cleaning up after us.');
+            $this->processor->cleanUp();
+        } catch (IOException $e) {
+            $this->logger->error('[dizda-backup] Cleaning up failed.');
+
+            return false;
+        }
+
+        return $successful;
     }
 }

--- a/Manager/BackupManager.php
+++ b/Manager/BackupManager.php
@@ -65,7 +65,7 @@ class BackupManager
 
         } catch (\Exception $e) {
             // Write log
-            $this->logger->critical('[dizda-backup] Unexpected exception.', array('exception' => $e->getMessage()));
+            $this->logger->critical('[dizda-backup] Unexpected exception.', array('exception' => $e));
 
             return false;
         } finally {

--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -51,7 +51,12 @@ class ClientManager
     {
         foreach ($this->children as $child) {
             $this->logger->info(sprintf('[Dizda Backup] Uploading to %s', $child->getName()));
-            $child->upload($filePath);
+
+            try {
+                $child->upload($filePath);
+            } catch (\Exception $e) {
+                $this->logger->error($e->getMessage());
+            }
         }
     }
 }

--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -49,14 +49,20 @@ class ClientManager
      */
     public function upload($filePath)
     {
+        $exception = null;
         foreach ($this->children as $child) {
             $this->logger->info(sprintf('[Dizda Backup] Uploading to %s', $child->getName()));
 
             try {
                 $child->upload($filePath);
             } catch (\Exception $e) {
-                $this->logger->error($e->getMessage());
+                //save the exception for later, there might be other children that are working
+                $exception = $e;
             }
+        }
+
+        if ($exception) {
+            throw $exception;
         }
     }
 }


### PR DESCRIPTION
We should not use console output in the clients. We should throw exceptions. These exceptions should later be caught and logged. 