### PR TITLE
Configure the proper branch alias and better symfony verison

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 
     "require-dev": {
         "google/apiclient": "@dev",
-        "symfony/symfony": "~2.3.25"
+        "symfony/symfony": "^2.3.25"
     },
 
     "suggest": {
@@ -47,7 +47,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
We should use the caret operator.
``` bash
"~2.3.25" => ">=2.3.25 < 2.4"
"^2.3.25" => ">=2.3.25 < 3.0"
```

https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-and-caret-operators-

I did also configure the branch alias. 