### PR TITLE
Added warning if you not run the command in production

### DIFF
--- a/Command/BackupCommand.php
+++ b/Command/BackupCommand.php
@@ -31,6 +31,8 @@ class BackupCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->checkEnvironment($output);
+
         if (!$this->getContainer()->get('dizda.cloudbackup.manager.backup')->execute()) {
             $output->writeln('<error>Something went terribly wrong. We could not create a backup. Read your log files to see what caused this error.</error>');
 
@@ -38,5 +40,20 @@ class BackupCommand extends ContainerAwareCommand
         }
 
         $output->writeln('<info>Backup complete.</info>');
+    }
+
+    /**
+     * Print a warning if we do not run the command in production environment
+     *
+     * @param OutputInterface $output
+     */
+    protected function checkEnvironment(OutputInterface $output)
+    {
+        if ($this->getContainer()->get('kernel')->getEnvironment() !== 'prod') {
+            $output->writeln('<bg=yellow>                                                                            </bg=yellow>');
+            $output->writeln('<bg=yellow;options=bold>  Warning:                                                                  </bg=yellow;options=bold>');
+            $output->writeln('<bg=yellow>  You shoild run the command in production environment ("--env=prod")       </bg=yellow>');
+            $output->writeln('<bg=yellow>                                                                            </bg=yellow>');
+        }
     }
 }

--- a/Manager/ClientManager.php
+++ b/Manager/ClientManager.php
@@ -53,7 +53,7 @@ class ClientManager
 
         //for each client
         foreach ($this->children as $child) {
-            $this->logger->info(sprintf('[Dizda Backup] Uploading to %s', $child->getName()));
+            $this->logger->info(sprintf('[dizda-backup] Uploading to %s', $child->getName()));
 
             try {
                 //try to upload every file, one at a time

--- a/Manager/DatabaseManager.php
+++ b/Manager/DatabaseManager.php
@@ -48,7 +48,7 @@ class DatabaseManager
     public function dump()
     {
         foreach ($this->children as $child) {
-            $this->logger->info(sprintf('[Dizda Backup] Dumping %s database', $child->getName()));
+            $this->logger->info(sprintf('[dizda-backup] Dumping %s database', $child->getName()));
             $child->dump();
         }
     }


### PR DESCRIPTION
You should run this command with the --env=prod. This will:

* Backup the correct database
* Enable logging/alert

It is really a command that you want to know if it fails or not. This is why I think there should be a reminder if you not running the command in production. 