### PR TITLE
add apostrophe to allow special characters in password

### DIFF
--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -20,7 +20,7 @@ class ZipProcessor extends BaseProcessor implements ProcessorInterface
         $params = array('-r');
 
         if (isset($this->options['password']) && $this->options['password']) {
-            $params[] = '-P '.$this->options['password'];
+            $params[] = '-P "'.$this->options['password'].'"';
         }
 
         if (isset($this->options['compression_ratio']) && $this->options['compression_ratio'] >= 0) {


### PR DESCRIPTION
Surround password in parameter option with " to allow passwords like "password:)"