### PR TITLE
add apostrophe to allow special characters in password

### DIFF
--- a/Processor/SevenZipProcessor.php
+++ b/Processor/SevenZipProcessor.php
@@ -20,7 +20,7 @@ class SevenZipProcessor extends BaseProcessor implements ProcessorInterface
         $params = array();
 
         if (isset($this->options['password']) && $this->options['password']) {
-            $params[] = '-p'.$this->options['password'];
+            $params[] = '-p "'.$this->options['password'].'"';
         }
 
         if (isset($this->options['compression_ratio']) && $this->options['compression_ratio'] >= 0) {

--- a/Processor/SevenZipProcessor.php
+++ b/Processor/SevenZipProcessor.php
@@ -20,7 +20,7 @@ class SevenZipProcessor extends BaseProcessor implements ProcessorInterface
         $params = array();
 
         if (isset($this->options['password']) && $this->options['password']) {
-            $params[] = '-p "'.$this->options['password'].'"';
+            $params[] = '-p"'.$this->options['password'].'"';
         }
 
         if (isset($this->options['compression_ratio']) && $this->options['compression_ratio'] >= 0) {

--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -20,7 +20,7 @@ class ZipProcessor extends BaseProcessor implements ProcessorInterface
         $params = array('-r');
 
         if (isset($this->options['password']) && $this->options['password']) {
-            $params[] = '-P '.$this->options['password'];
+            $params[] = '-P "'.$this->options['password'].'"';
         }
 
         if (isset($this->options['compression_ratio']) && $this->options['compression_ratio'] >= 0) {

--- a/Tests/Processor/SevenZipTest.php
+++ b/Tests/Processor/SevenZipTest.php
@@ -29,7 +29,7 @@ class SevenZipTest extends \PHPUnit_Framework_TestCase
         $processor = new SevenZipProcessor(array('password' => 'qwerty'));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            'cd $outputPath && 7z a -p "qwerty" $archivePath'
+            "cd $outputPath && 7z a -p \"qwerty\" $archivePath"
         );
 
         // compress with compression rate = 0

--- a/Tests/Processor/SevenZipTest.php
+++ b/Tests/Processor/SevenZipTest.php
@@ -29,7 +29,7 @@ class SevenZipTest extends \PHPUnit_Framework_TestCase
         $processor = new SevenZipProcessor(array('password' => 'qwerty'));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "cd $outputPath && 7z a -p \"qwerty\" $archivePath"
+            "cd $outputPath && 7z a -p\"qwerty\" $archivePath"
         );
 
         // compress with compression rate = 0

--- a/Tests/Processor/SevenZipTest.php
+++ b/Tests/Processor/SevenZipTest.php
@@ -29,7 +29,7 @@ class SevenZipTest extends \PHPUnit_Framework_TestCase
         $processor = new SevenZipProcessor(array('password' => 'qwerty'));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "cd $outputPath && 7z a -pqwerty $archivePath"
+            'cd $outputPath && 7z a -p "qwerty" $archivePath'
         );
 
         // compress with compression rate = 0

--- a/Tests/Processor/ZipTest.php
+++ b/Tests/Processor/ZipTest.php
@@ -29,7 +29,7 @@ class ZipTest extends \PHPUnit_Framework_TestCase
         $processor = new ZipProcessor(array('password' => 'qwerty'));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "cd $outputPath && zip -r -P qwerty $archivePath ."
+            'cd $outputPath && zip -r -P "qwerty" $archivePath .'
         );
 
         // compress with compression rate = 0

--- a/Tests/Processor/ZipTest.php
+++ b/Tests/Processor/ZipTest.php
@@ -29,7 +29,7 @@ class ZipTest extends \PHPUnit_Framework_TestCase
         $processor = new ZipProcessor(array('password' => 'qwerty'));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            'cd $outputPath && zip -r -P "qwerty" $archivePath .'
+            "cd $outputPath && zip -r -P \"qwerty\" $archivePath ."
         );
 
         // compress with compression rate = 0


### PR DESCRIPTION
Surround password in parameter option with " to allow passwords like "password:)"