### PR TITLE
Fix bug when using multiple gaufrette filesystems

### DIFF
--- a/Client/GaufretteClient.php
+++ b/Client/GaufretteClient.php
@@ -12,7 +12,7 @@ use Gaufrette\Filesystem;
  */
 class GaufretteClient implements ClientInterface
 {
-    private $filesystem;
+    private $filesystems;
 
     /**
      * {@inheritdoc}
@@ -20,7 +20,9 @@ class GaufretteClient implements ClientInterface
     public function upload($archive)
     {
         $fileName = explode('/', $archive);
-        $this->filesystem->write(end($fileName), file_get_contents($archive), true);
+        foreach ($this->filesystems as $filesystem) {
+            $filesystem->write(end($fileName), file_get_contents($archive), true);
+        }
     }
 
     /**
@@ -28,9 +30,9 @@ class GaufretteClient implements ClientInterface
      *
      * @param \Gaufrette\Filesystem $filesystem
      */
-    public function setFilesystem(Filesystem $filesystem)
+    public function addFilesystem(Filesystem $filesystem)
     {
-        $this->filesystem = $filesystem;
+        $this->filesystems[] = $filesystem;
     }
 
     /**

--- a/DependencyInjection/Compiler/TaggedServicesPass.php
+++ b/DependencyInjection/Compiler/TaggedServicesPass.php
@@ -77,7 +77,7 @@ class TaggedServicesPass implements CompilerPassInterface
             foreach($filesystem as $filesystemName)
             {
                 $gaufrette = $container->getDefinition('dizda.cloudbackup.client.gaufrette');
-                $gaufrette->addMethodCall('setFilesystem', [
+                $gaufrette->addMethodCall('addFilesystem', [
                     new Reference($filesystemName),
                 ]);
             }


### PR DESCRIPTION
This is related to this previous PR :
https://github.com/dizda/CloudBackupBundle/pull/72
I did a mistake.

Multiple filesystems was still not working : all filesystems except the last one was ignored.

This is because we were doing a `setFilesystem` on every filesystems. So the last one was overriding all others.

Instead we can consider 2 approach :
1 - Using multiple `GaufretteClient` (one per filesystem), and add them all to the `ClientManager` as `$children`.
2 - Using 1 `GaufretteClient` to handle all the filesystems, and keep just one `GaufretteClient` attached to the `ClientManager`

I think the second option is better. What do you think ?
This PR implement the second option.

Also, not sure if pluralize the property `$filesystem` of the class `GaufretteClient` is a best practice ?
https://github.com/FrancoisMartin/CloudBackupBundle/blob/master/Client/GaufretteClient.php#l15