### PR TITLE
Require php 5.4 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false 
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
 
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "symfony/framework-bundle": ">=2.1",
         "symfony/monolog-bundle": "~2.3"
     },


### PR DESCRIPTION
Php 5.3 security support ended over a year ago. Not even 5.4 have active security support and maybe we should require 5.5+?
