### PR TITLE
Escape Paths Aruments on Commandline

### DIFF
--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -1,6 +1,8 @@
 <?php
 namespace Dizda\CloudBackupBundle\Database;
 
+use Symfony\Component\Process\ProcessUtils;
+
 /**
  * Class MySQL.
  *
@@ -81,7 +83,8 @@ class MySQL extends BaseDatabase
             $this->auth,
             $this->database,
             $this->ignoreTables,
-            $this->dataPath.$this->fileName);
+            ProcessUtils::escapeArgument($this->dataPath.$this->fileName)
+        );
     }
 
     /**

--- a/Processor/TarProcessor.php
+++ b/Processor/TarProcessor.php
@@ -2,6 +2,8 @@
 
 namespace Dizda\CloudBackupBundle\Processor;
 
+use Symfony\Component\Process\ProcessUtils;
+
 class TarProcessor extends BaseProcessor implements ProcessorInterface
 {
     /**
@@ -27,9 +29,9 @@ class TarProcessor extends BaseProcessor implements ProcessorInterface
 
         return sprintf('tar %s c -C %s . | gzip %s > %s',
             implode(' ', $tarParams),
-            $basePath,
+            ProcessUtils::escapeArgument($basePath),
             implode(' ', $zipParams),
-            $archivePath
+            ProcessUtils::escapeArgument($archivePath)
         );
     }
 

--- a/Tests/Database/MySQLTest.php
+++ b/Tests/Database/MySQLTest.php
@@ -25,7 +25,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ),
         ), '/var/backup/');
 
-        $this->assertEquals($mysql->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" --all-databases  > /var/backup/mysql/all-databases.sql");
+        $this->assertEquals($mysql->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" --all-databases  > '/var/backup/mysql/all-databases.sql'");
     }
 
     /**
@@ -55,7 +55,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ),
         ), '/var/backup/');
 
-        $this->assertEquals($mysql1->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" dizbdd  > /var/backup/mysql/dizbdd.sql");
+        $this->assertEquals($mysql1->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" dizbdd  > '/var/backup/mysql/dizbdd.sql'");
         $this->assertEquals($mysql2->getCommand(), "mysqldump --host=\"somehost\" --port=\"2222\" --user=\"mysql\" --password=\"somepwd\" somebdd  > /var/backup/mysql/somebdd.sql");
 
         // dump specified database with no auth
@@ -90,7 +90,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ),
         ), '/var/backup/');
 
-        $this->assertEquals($mysql->getCommand(), 'mysqldump  --all-databases  > /var/backup/mysql/all-databases.sql');
+        $this->assertEquals($mysql->getCommand(), 'mysqldump  --all-databases  > \'/var/backup/mysql/all-databases.sql\'');
     }
 
     /**
@@ -110,7 +110,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ),
         ), '/var/backup/');
 
-        $this->assertEquals($mysql->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" dizbdd --ignore-table=dizbdd.table1 --ignore-table=dizbdd.table2  > /var/backup/mysql/dizbdd.sql");
+        $this->assertEquals($mysql->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" dizbdd --ignore-table=dizbdd.table1 --ignore-table=dizbdd.table2  > '/var/backup/mysql/dizbdd.sql'");
     }
 
     /**
@@ -130,7 +130,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ),
         ), '/var/backup/');
 
-        $this->assertEquals($mysql->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" --all-databases --ignore-table=db1.table1 --ignore-table=db2.table2  > /var/backup/mysql/all-databases.sql");
+        $this->assertEquals($mysql->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" --all-databases --ignore-table=db1.table1 --ignore-table=db2.table2  > '/var/backup/mysql/all-databases.sql'");
     }
 
     /**

--- a/Tests/Database/MySQLTest.php
+++ b/Tests/Database/MySQLTest.php
@@ -56,7 +56,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         ), '/var/backup/');
 
         $this->assertEquals($mysql1->getCommand(), "mysqldump --host=\"localhost\" --port=\"3306\" --user=\"root\" --password=\"test\" dizbdd  > '/var/backup/mysql/dizbdd.sql'");
-        $this->assertEquals($mysql2->getCommand(), "mysqldump --host=\"somehost\" --port=\"2222\" --user=\"mysql\" --password=\"somepwd\" somebdd  > /var/backup/mysql/somebdd.sql");
+        $this->assertEquals($mysql2->getCommand(), "mysqldump --host=\"somehost\" --port=\"2222\" --user=\"mysql\" --password=\"somepwd\" somebdd  > '/var/backup/mysql/somebdd.sql'");
 
         // dump specified database with no auth
         $mysql = new MySQLDummy(array(
@@ -70,7 +70,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ),
         ), '/var/backup/');
 
-        $this->assertEquals($mysql->getCommand(), 'mysqldump  somebdd  > /var/backup/mysql/somebdd.sql');
+        $this->assertEquals($mysql->getCommand(), 'mysqldump  somebdd  > \'/var/backup/mysql/somebdd.sql\'');
     }
 
     /**

--- a/Tests/Processor/TarTest.php
+++ b/Tests/Processor/TarTest.php
@@ -16,35 +16,35 @@ class TarTest extends \PHPUnit_Framework_TestCase
     public function testGetCompressionCommand()
     {
         // build necessary data
-        $outputPath  = ProcessUtils::escapeArgument('/var/backup/');
-        $archivePath = ProcessUtils::escapeArgument($outputPath . 'coucou.zip');
+        $outputPath  = '/var/backup/';
+        $archivePath = $outputPath . 'coucou.zip';
 
         // compress with default params
         $processor = new TarProcessor(array());
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "tar  c -C $outputPath . | gzip  > $archivePath"
+            "tar  c -C ". ProcessUtils::escapeArgument($outputPath)." . | gzip  > ". ProcessUtils::escapeArgument($archivePath)
         );
 
         // compress with password - password not used in tar processor
         $processor = new TarProcessor(array('password' => 'qwerty'));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "tar  c -C $outputPath . | gzip  > $archivePath"
+            "tar  c -C ". ProcessUtils::escapeArgument($outputPath)." . | gzip  > ". ProcessUtils::escapeArgument($archivePath)
         );
 
         // compress with compression rate = 0
         $processor = new TarProcessor(array('compression_ratio' => 0));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "tar  c -C $outputPath . | gzip -0 > $archivePath"
+            "tar  c -C ". ProcessUtils::escapeArgument($outputPath)." . | gzip -0 > ". ProcessUtils::escapeArgument($archivePath)
         );
 
         // compress with compression rate = 9
         $processor = new TarProcessor(array('compression_ratio' => 9));
         $this->assertEquals(
             $processor->getCompressionCommand($archivePath, $outputPath),
-            "tar  c -C $outputPath . | gzip -9 > $archivePath"
+            "tar  c -C ". ProcessUtils::escapeArgument($outputPath)." . | gzip -9 > ". ProcessUtils::escapeArgument($archivePath)
         );
     }
 }

--- a/Tests/Processor/TarTest.php
+++ b/Tests/Processor/TarTest.php
@@ -3,6 +3,7 @@
 namespace Dizda\CloudBackupBundle\Tests\Processor;
 
 use Dizda\CloudBackupBundle\Processor\TarProcessor;
+use Symfony\Component\Process\ProcessUtils;
 
 /**
  * Class TarTest.
@@ -15,8 +16,8 @@ class TarTest extends \PHPUnit_Framework_TestCase
     public function testGetCompressionCommand()
     {
         // build necessary data
-        $outputPath  = '/var/backup/';
-        $archivePath = $outputPath . 'coucou.zip';
+        $outputPath  = ProcessUtils::escapeArgument('/var/backup/');
+        $archivePath = ProcessUtils::escapeArgument($outputPath . 'coucou.zip');
 
         // compress with default params
         $processor = new TarProcessor(array());


### PR DESCRIPTION
Paths should be escaped for better portability.