### PR TITLE
Fixed mock warning for undefined method

### DIFF
--- a/Tests/Client/GoogleDriveClientTest.php
+++ b/Tests/Client/GoogleDriveClientTest.php
@@ -39,9 +39,6 @@ class GoogleDriveClientTest extends \PHPUnit_Framework_TestCase
             ->setMethods(array('getClient', 'uploadFileInChunks', 'getMediaUploadFile', 'getDriveService', 'getDriveFile', 'getMimeType', 'getParentFolder'))
             ->getMock();
 
-        $drive->expects($this->any())
-            ->method('output');
-
         $drive->expects($this->once())
             ->method('getDriveService')
             ->willReturn($driveService);


### PR DESCRIPTION
The tests gave a warning for method `output` which does not exist in `GoogleDriveClient`. Guess this is correct @Nyholm 

<img width="708" alt="screenshot 2016-10-18 20 36 59" src="https://cloud.githubusercontent.com/assets/165154/19491328/d8d59896-9572-11e6-8589-a7efb97d7fc2.png">
