### PR TITLE
Remove Monolog Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 
     "require": {
         "php": "^5.4 || ^7.0",
-        "symfony/framework-bundle": "^2.1 || ^3.0"
+        "symfony/framework-bundle": "^2.1 || ^3.0",
+        "psr/log": "^1.0.1"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
 
     "require": {
         "php": "^5.4 || ^7.0",
-        "symfony/framework-bundle": "^2.1 || ^3.0",
-        "symfony/monolog-bundle": "^2.3"
+        "symfony/framework-bundle": "^2.1 || ^3.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
I am now using this with a Symfony 3.2 RC project and having some dependency issues. Couldn't figure out why monolog was even used in this project.

Edit: I obviously didn't look hard enough since I grepped for Monolog. It's clear that the LoggerInterface is used a lot. Added dependency for just the interface.