### PR TITLE
Fix chmod for mysql configuration file

### DIFF
--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -91,7 +91,8 @@ class MySQL extends BaseDatabase
                 $cnfFile .= "$key = \"$value\"\n";
             }
 
-            $this->filesystem->dumpFile($this->getConfigurationFilePath(), $cnfFile, 0600);
+            $this->filesystem->dumpFile($this->getConfigurationFilePath(), $cnfFile);
+            $this->filesystem->chmod([$this->getConfigurationFilePath()], 0600);
             $this->auth = sprintf("--defaults-extra-file=\"%s\"", $this->getConfigurationFilePath());
         }
     }


### PR DESCRIPTION
In [Filesystem component >= 3.0](https://github.com/symfony/filesystem/blob/master/Filesystem.php#L629) third argument is removed. Result - file is created with 0666 mask. As stated in docs, [ On Unix platforms, MySQL ignores configuration files that are world-writable.](https://dev.mysql.com/doc/refman/5.7/en/option-files.html), so mysqldump tries to connect with user, under which it was executed. I would recommend to merge it as soon as possible, release and recommend all users with Symfony >=3.0 to upgrade. 