### PR TITLE
Added executable binary path option for zip and 7z

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('options')
                         ->addDefaultsIfNotSet()
                         ->children()
+                            ->scalarNode('executable')->defaultNull()->end()
                             ->scalarNode('password')->defaultNull()->end()
                             ->integerNode('compression_ratio')->defaultValue(6)->min(0)->max(100)->end()
                             ->arrayNode('split')

--- a/Processor/SevenZipProcessor.php
+++ b/Processor/SevenZipProcessor.php
@@ -33,7 +33,9 @@ class SevenZipProcessor extends BaseProcessor implements ProcessorInterface
             $params[] = '-mx'.$compression_ratio;
         }
 
-        return sprintf('cd %s && 7z a %s %s', $basePath, implode(' ', $params), $archivePath);
+        $binaryFile = escapeshellarg(isset($this->options['executable']) ? $this->options['executable'] : '7z');
+
+        return sprintf('cd %s && %s a %s %s', $basePath, $binaryFile, implode(' ', $params), $archivePath);
     }
 
     /**

--- a/Processor/SevenZipProcessor.php
+++ b/Processor/SevenZipProcessor.php
@@ -33,7 +33,7 @@ class SevenZipProcessor extends BaseProcessor implements ProcessorInterface
             $params[] = '-mx'.$compression_ratio;
         }
 
-        $binaryFile = escapeshellarg(isset($this->options['executable']) ? $this->options['executable'] : '7z');
+        $binaryFile = escapeshellarg($this->options['executable'] ?: '7z');
 
         return sprintf('cd %s && %s a %s %s', $basePath, $binaryFile, implode(' ', $params), $archivePath);
     }

--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -28,7 +28,7 @@ class ZipProcessor extends BaseProcessor implements ProcessorInterface, Uncompre
             $params[] = '-'.$compression_ratio;
         }
 
-        $binaryFile = escapeshellarg(isset($this->options['executable']) ? $this->options['executable'] : 'zip');
+        $binaryFile = escapeshellarg($this->options['executable'] ?: 'zip');
 
         return sprintf('cd %s && %s %s %s .', $basePath, $binaryFile, implode(' ', $params), $archivePath);
     }

--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -28,7 +28,9 @@ class ZipProcessor extends BaseProcessor implements ProcessorInterface, Uncompre
             $params[] = '-'.$compression_ratio;
         }
 
-        return sprintf('cd %s && zip %s %s .', $basePath, implode(' ', $params), $archivePath);
+	    $binaryFile = escapeshellarg(isset($this->options['executable']) ? $this->options['executable'] : 'zip');
+
+        return sprintf('cd %s && %s %s %s .', $basePath, $binaryFile, implode(' ', $params), $archivePath);
     }
 
     /**

--- a/Processor/ZipProcessor.php
+++ b/Processor/ZipProcessor.php
@@ -28,7 +28,7 @@ class ZipProcessor extends BaseProcessor implements ProcessorInterface, Uncompre
             $params[] = '-'.$compression_ratio;
         }
 
-	    $binaryFile = escapeshellarg(isset($this->options['executable']) ? $this->options['executable'] : 'zip');
+        $binaryFile = escapeshellarg(isset($this->options['executable']) ? $this->options['executable'] : 'zip');
 
         return sprintf('cd %s && %s %s %s .', $basePath, $binaryFile, implode(' ', $params), $archivePath);
     }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ dizda_cloud_backup:
     processor:
         type: tar # Required: tar|zip|7z
         options:
+            executable: zip|7z # If not added to path variable please set binary path for zip and 7z! e.g. on Windows: 'C:\Program Files\7-Zip\7z.exe'
             compression_ratio: 6
             password: qwerty
             # Split into many files of `split_size` bytes

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ dizda_cloud_backup:
 
 ```yml
 # app/config/parameters.yml
-	# ...
+  # ...
     database_driver: pdo_mysql
     database_host: localhost
     database_port: null


### PR DESCRIPTION
I want to use this bundle on a Amazon ElasticBeanstalk Environment.
If I want to use 7zip I must install it via this command.

    yum -y --enablerepo=epel install p7zip

And then I can execute it via `7za`.
But in this bundle the default is `7z` so I cant execute them.

Linux solution will be to make a symlink from 7z to 7za. This should work, too. (Temporarily)

But on my windows development environment I want to test it, too - without changing path variable. So now I can add `executable: 'C:\Program Files\7-Zip\7z.exe'` to config.yml and it works.
Other solution is to add it to path.


I added this functionality for zip, too. But not for tar because then we need two executable paths.