### PR TITLE
Mysql Command line options (no lock & host/port)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ php:
   - 7.0
   - hhvm
   
-before_script: composer install --prefer-source
+before_script:
+  - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then composer require happyr/google-site-authenticator-bundle; fi
+  - composer install --prefer-source
 
 script: phpunit --debug --coverage-text
 

--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -164,7 +164,7 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
      */
     protected function getCommand()
     {
-        return sprintf('mysqldump %s %s %s > %s',
+        return sprintf('mysqldump %s %s %s %s > %s',
             $this->auth,
             $this->database,
             $this->ignoreTables,

--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -18,6 +18,7 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
     private $auth = '';
     private $fileName;
     private $ignoreTables = '';
+    private $singleTransaction = '';
     private $params;
 
     /**
@@ -49,6 +50,13 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
         } else {
             $this->database = $this->params['database'];
             $this->fileName = $this->database . '.sql';
+        }
+    }
+
+    protected function prepareSingleTransaction()
+    {
+        if ($this->params['single_transaction']) {
+            $this->singleTransaction = '--single-transaction';
         }
     }
 
@@ -129,6 +137,7 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
         $this->preparePath();
         $this->prepareFileName();
         $this->prepareIgnoreTables();
+        $this->prepareSingleTransaction();
         $this->prepareConfigurationFile();
     }
 
@@ -159,6 +168,7 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
             $this->auth,
             $this->database,
             $this->ignoreTables,
+            $this->singleTransaction,
             ProcessUtils::escapeArgument($this->dataPath.$this->fileName)
         );
     }

--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -164,7 +164,7 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
      */
     protected function getCommand()
     {
-        return sprintf('mysqldump %s %s %s %s > %s',
+        return sprintf('mysqldump %s %s %s %s> %s',
             $this->auth,
             $this->database,
             $this->ignoreTables,

--- a/Database/MySQL.php
+++ b/Database/MySQL.php
@@ -193,8 +193,20 @@ class MySQL extends BaseDatabase implements RestorableDatabaseInterface
 
         $this->prepareFileName();
 
-        $command = sprintf('mysql %s %s < %s',
+        $restoreHost = '';
+        if ($this->params['db_host']) {
+            $restoreHost = sprintf('-h%s', $this->params['db_host']);
+        }
+
+        $restorePort = '';
+        if ($this->params['db_port']) {
+            $restorePort = sprintf('-P%s', $this->params['db_port']);
+        }
+
+        $command = sprintf('mysql %s %s %s %s < %s',
             $restoreAuth,
+            $restoreHost,
+            $restorePort,
             $this->params['database'],
             ProcessUtils::escapeArgument(sprintf('%smysql/%s', $this->restoreFolder, $this->fileName))
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -119,6 +119,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('db_port')->defaultValue(3306)->end()
                             ->scalarNode('db_user')->defaultNull()->end()
                             ->scalarNode('db_password')->defaultNull()->end()
+                            ->booleanNode('single_transaction')->defaultFalse()->end()
                             ->arrayNode('ignore_tables')
                                 ->prototype('scalar')->end()
                             ->end()

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ dizda_cloud_backup:
             db_port: ~           # Default 3306
             db_user: ~
             db_password: ~
+	    single_transaction: false
             ignore_tables:       # Specify full name if dumping all databases. `dbname.tablename`
                 - table1
                 - table2

--- a/Tests/Client/GaufretteClientTest.php
+++ b/Tests/Client/GaufretteClientTest.php
@@ -7,8 +7,27 @@ use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Symfony\Component\Filesystem\Filesystem as LocalFilesystem;
 
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class GaufretteClientTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Compatibility for older PHPUnit versions
+     *
+     * @param string $originalClassName
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($originalClassName) {
+        if(is_callable(array('parent', 'createMock'))) {
+            return parent::createMock($originalClassName);
+        } else {
+            return $this->getMock($originalClassName);
+        }
+    }
+
     /**
      * @test
      */

--- a/Tests/Client/GaufretteClientTest.php
+++ b/Tests/Client/GaufretteClientTest.php
@@ -7,14 +7,14 @@ use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Symfony\Component\Filesystem\Filesystem as LocalFilesystem;
 
-class GaufretteClientTest extends \PHPUnit_Framework_TestCase
+class GaufretteClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
      */
     public function shouldDownloadAndSaveContentInANewFile()
     {
-        $localFilesystemMock = $this->getMock(LocalFilesystem::class);
+        $localFilesystemMock = $this->createMock(LocalFilesystem::class);
         $localFilesystemMock->expects($this->once())->method('dumpFile')
             ->with('/tmp/restore/db_2016-10-19.zip', 'foo bar');
         $client = new GaufretteClient('/tmp/restore/', $localFilesystemMock);
@@ -47,7 +47,7 @@ class GaufretteClientTest extends \PHPUnit_Framework_TestCase
      */
     public function throwExceptionIfRestoreFolderIsNotConfigured()
     {
-        $client = new GaufretteClient(null, $this->getMock(LocalFilesystem::class));
+        $client = new GaufretteClient(null, $this->createMock(LocalFilesystem::class));
         $client->download();
     }
 }

--- a/Tests/Client/GoogleDriveClientTest.php
+++ b/Tests/Client/GoogleDriveClientTest.php
@@ -7,14 +7,14 @@ use Dizda\CloudBackupBundle\Client\GoogleDriveClient;
 /**
  * @author Tobias Nyholm
  */
-class GoogleDriveClientTest extends \PHPUnit_Framework_TestCase
+class GoogleDriveClientTest extends \PHPUnit\Framework\TestCase
 {
     public function testUpload()
     {
         $archive = '/biz/baz/boz';
         $mime = 'mime';
-        $clientProvider = $this->getMock('Happyr\GoogleSiteAuthenticatorBundle\Service\ClientProvider');
-        $driveParent = $this->getMock('Google_Service_Drive_ParentReference');
+        $clientProvider = $this->createMock('Happyr\GoogleSiteAuthenticatorBundle\Service\ClientProvider');
+        $driveParent = $this->createMock('Google_Service_Drive_ParentReference');
         $driveService = $this->getDriveService();
 
         $client = $this->getMockBuilder('Google_Client')
@@ -25,7 +25,7 @@ class GoogleDriveClientTest extends \PHPUnit_Framework_TestCase
         $client->expects($this->once())
             ->method('setDefer');
 
-        $driveFile = $this->getMock('Google_Service_Drive_DriveFile');
+        $driveFile = $this->createMock('Google_Service_Drive_DriveFile');
         $driveFile->expects($this->once())
             ->method('setMimeType')
             ->with($this->equalTo($mime));
@@ -88,7 +88,7 @@ class GoogleDriveClientTest extends \PHPUnit_Framework_TestCase
             ->method('insert')
             ->willReturn('request');
 
-        $driveService = $this->getMockBuilder('Google_Service_Drive')
+        $driveService = $this->createMockBuilder('Google_Service_Drive')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/Client/GoogleDriveClientTest.php
+++ b/Tests/Client/GoogleDriveClientTest.php
@@ -7,8 +7,27 @@ use Dizda\CloudBackupBundle\Client\GoogleDriveClient;
 /**
  * @author Tobias Nyholm
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class GoogleDriveClientTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Compatibility for older PHPUnit versions
+     *
+     * @param string $originalClassName
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($originalClassName) {
+        if(is_callable(array('parent', 'createMock'))) {
+            return parent::createMock($originalClassName);
+        } else {
+            return $this->getMock($originalClassName);
+        }
+    }
+
     public function testUpload()
     {
         $archive = '/biz/baz/boz';
@@ -88,7 +107,7 @@ class GoogleDriveClientTest extends \PHPUnit\Framework\TestCase
             ->method('insert')
             ->willReturn('request');
 
-        $driveService = $this->createMockBuilder('Google_Service_Drive')
+        $driveService = $this->getMockBuilder('Google_Service_Drive')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Tests/Database/MongoDBTest.php
+++ b/Tests/Database/MongoDBTest.php
@@ -7,6 +7,11 @@ use Dizda\CloudBackupBundle\Database\MongoDB;
 /**
  * Class MongoDBTest.
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class MongoDBTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Tests/Database/MongoDBTest.php
+++ b/Tests/Database/MongoDBTest.php
@@ -7,7 +7,7 @@ use Dizda\CloudBackupBundle\Database\MongoDB;
 /**
  * Class MongoDBTest.
  */
-class MongoDBTest extends \PHPUnit_Framework_TestCase
+class MongoDBTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test different commands.

--- a/Tests/Database/MySQLTest.php
+++ b/Tests/Database/MySQLTest.php
@@ -7,7 +7,7 @@ use Dizda\CloudBackupBundle\Database\MySQL;
 /**
  * Class MySQLTest.
  */
-class MySQLTest extends \PHPUnit_Framework_TestCase
+class MySQLTest extends \PHPUnit\Framework\TestCase
 {
     protected function checkConfigurationFileExistsAndValid($user, $password, $host, $port)
     {

--- a/Tests/Database/MySQLTest.php
+++ b/Tests/Database/MySQLTest.php
@@ -30,6 +30,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => true,
+                'single_transaction' => false,
                 'db_host'       => 'localhost',
                 'db_port'       => 3306,
                 'database'      => 'dizbdd',
@@ -50,6 +51,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql1 = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => false,
+                'single_transaction' => false,
                 'db_host'       => 'localhost',
                 'db_port'       => 3306,
                 'database'      => 'dizbdd',
@@ -64,6 +66,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql2 = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => false,
+                'single_transaction' => false,
                 'db_host'       => 'somehost',
                 'db_port'       => 2222,
                 'database'      => 'somebdd',
@@ -79,6 +82,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => false,
+                'single_transaction' => false,
                 'db_host'       => 'somehost',
                 'db_port'       => 2222,
                 'database'      => 'somebdd',
@@ -100,6 +104,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => true,
+                'single_transaction' => false,
                 'db_host'       => 'somehost',
                 'db_port'       => 2222,
                 'database'      => 'somebdd',
@@ -120,6 +125,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => false,
+                'single_transaction' => false,
                 'db_host'       => 'localhost',
                 'db_port'       => 3306,
                 'database'      => 'dizbdd',
@@ -141,6 +147,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => true,
+                'single_transaction' => false,
                 'db_host'       => 'localhost',
                 'db_port'       => 3306,
                 'database'      => null,
@@ -163,6 +170,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
         $mysql = new MySQLDummy(array(
             'mysql' => array(
                 'all_databases' => true,
+                'single_transaction' => false,
                 'db_host'       => 'localhost',
                 'db_port'       => 3306,
                 'database'      => null,
@@ -191,7 +199,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $this->assertEquals('mysql -uroot dizbdd < \'/tmp/restore/mysql/dizbdd.sql\'', $mysql->getRestoreCommand());
+        $this->assertEquals('mysql -uroot -hlocalhost -P3306 dizbdd < \'/tmp/restore/mysql/dizbdd.sql\'', $mysql->getRestoreCommand());
     }
 
     /**
@@ -210,7 +218,7 @@ class MySQLTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $this->assertEquals('mysql -uroot --password="foobar" dizbdd < \'/tmp/restore/mysql/dizbdd.sql\'', $mysql->getRestoreCommand());
+        $this->assertEquals('mysql -uroot --password="foobar" -hlocalhost -P3306 dizbdd < \'/tmp/restore/mysql/dizbdd.sql\'', $mysql->getRestoreCommand());
     }
 
     /**

--- a/Tests/Database/MySQLTest.php
+++ b/Tests/Database/MySQLTest.php
@@ -7,6 +7,11 @@ use Dizda\CloudBackupBundle\Database\MySQL;
 /**
  * Class MySQLTest.
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class MySQLTest extends \PHPUnit\Framework\TestCase
 {
     protected function checkConfigurationFileExistsAndValid($user, $password, $host, $port)

--- a/Tests/Database/PostgreSQLTest.php
+++ b/Tests/Database/PostgreSQLTest.php
@@ -7,6 +7,11 @@ use Dizda\CloudBackupBundle\Database\PostgreSQL;
 /**
  * Class PostgreSQLTest.
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class PostgreSQLTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Tests/Database/PostgreSQLTest.php
+++ b/Tests/Database/PostgreSQLTest.php
@@ -7,7 +7,7 @@ use Dizda\CloudBackupBundle\Database\PostgreSQL;
 /**
  * Class PostgreSQLTest.
  */
-class PostgreSQLTest extends \PHPUnit_Framework_TestCase
+class PostgreSQLTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test different commands.

--- a/Tests/Manager/BackupManagerTest.php
+++ b/Tests/Manager/BackupManagerTest.php
@@ -5,18 +5,18 @@ namespace Dizda\CloudBackupBundle\Tests\Manager;
 use Dizda\CloudBackupBundle\Event\BackupEvent;
 use Dizda\CloudBackupBundle\Manager\BackupManager;
 
-class BackupManagerTest extends \PHPUnit_Framework_TestCase
+class BackupManagerTest extends \PHPUnit\Framework\TestCase
 {
     public function testBackupCompletedEventIsCalledOnSuccess()
     {
-        $loggerMock = $this->getMock('Psr\Log\LoggerInterface');
+        $loggerMock = $this->createMock('Psr\Log\LoggerInterface');
         $databaseManagerMock = $this->getMockBuilder('Dizda\CloudBackupBundle\Manager\DatabaseManager')
             ->disableOriginalConstructor()->getMock();
         $clientManagerMock = $this->getMockBuilder('Dizda\CloudBackupBundle\Manager\ClientManager')
             ->disableOriginalConstructor()->getMock();
         $processorManagerMock = $this->getMockBuilder('Dizda\CloudBackupBundle\Manager\ProcessorManager')
             ->disableOriginalConstructor()->getMock();
-        $eventDispatcherMock = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcherMock = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $eventDispatcherMock->expects($this->once())->method('dispatch')->with(BackupEvent::BACKUP_COMPLETED);
 
         $backupManager = new BackupManager(
@@ -27,7 +27,7 @@ class BackupManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testBackupCompletedEventIsNotCalledWhenFailed()
     {
-        $loggerMock = $this->getMock('Psr\Log\LoggerInterface');
+        $loggerMock = $this->createMock('Psr\Log\LoggerInterface');
         $databaseManagerMock = $this->getMockBuilder('Dizda\CloudBackupBundle\Manager\DatabaseManager')
             ->disableOriginalConstructor()->getMock();
         $clientManagerMock = $this->getMockBuilder('Dizda\CloudBackupBundle\Manager\ClientManager')
@@ -36,7 +36,7 @@ class BackupManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()->getMock();
         $processorManagerMock->expects($this->once())->method('copyFolders')
             ->will($this->throwException(new \Exception()));
-        $eventDispatcherMock = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcherMock = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $eventDispatcherMock->expects($this->never())->method('dispatch')->with(BackupEvent::BACKUP_COMPLETED);
 
         $backupManager = new BackupManager(

--- a/Tests/Manager/BackupManagerTest.php
+++ b/Tests/Manager/BackupManagerTest.php
@@ -5,8 +5,27 @@ namespace Dizda\CloudBackupBundle\Tests\Manager;
 use Dizda\CloudBackupBundle\Event\BackupEvent;
 use Dizda\CloudBackupBundle\Manager\BackupManager;
 
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class BackupManagerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Compatibility for older PHPUnit versions
+     *
+     * @param string $originalClassName
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($originalClassName) {
+        if(is_callable(array('parent', 'createMock'))) {
+            return parent::createMock($originalClassName);
+        } else {
+            return $this->getMock($originalClassName);
+        }
+    }
+
     public function testBackupCompletedEventIsCalledOnSuccess()
     {
         $loggerMock = $this->createMock('Psr\Log\LoggerInterface');

--- a/Tests/Manager/ClientManagerTest.php
+++ b/Tests/Manager/ClientManagerTest.php
@@ -6,7 +6,7 @@ use Dizda\CloudBackupBundle\Client\DownloadableClientInterface;
 use Dizda\CloudBackupBundle\Manager\ClientManager;
 use Psr\Log\LoggerInterface;
 
-class ClientManagerTest extends \PHPUnit_Framework_TestCase
+class ClientManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
@@ -14,8 +14,8 @@ class ClientManagerTest extends \PHPUnit_Framework_TestCase
     public function shouldExecuteDownloadForFirstDownloadableClient()
     {
         $clients = [];
-        $clients[] = $this->getMock(ClientInterface::class);
-        $clientMock = $this->getMock(DownloadableClientInterface::class);
+        $clients[] = $this->createMock(ClientInterface::class);
+        $clientMock = $this->createMock(DownloadableClientInterface::class);
         $fileMock = $this
             ->getMockBuilder(\SplFileInfo::class)
             ->setConstructorArgs([tempnam(sys_get_temp_dir(), '')])
@@ -23,7 +23,7 @@ class ClientManagerTest extends \PHPUnit_Framework_TestCase
         $clientMock->expects($this->once())->method('download')->willReturn($fileMock);
         $clients[] = $clientMock;
 
-        $clientManager = new ClientManager($this->getMock(LoggerInterface::class), $clients);
+        $clientManager = new ClientManager($this->createMock(LoggerInterface::class), $clients);
         $this->assertSame($fileMock, $clientManager->download());
     }
 
@@ -35,10 +35,10 @@ class ClientManagerTest extends \PHPUnit_Framework_TestCase
     public function shouldThrowExceptionIfNoChildIsADownloadableClient()
     {
         $clients = [];
-        $clients[] = $this->getMock(ClientInterface::class);
-        $clients[] = $this->getMock(ClientInterface::class);
+        $clients[] = $this->createMock(ClientInterface::class);
+        $clients[] = $this->createMock(ClientInterface::class);
 
-        $clientManager = new ClientManager($this->getMock(LoggerInterface::class), $clients);
+        $clientManager = new ClientManager($this->createMock(LoggerInterface::class), $clients);
         $clientManager->download();
     }
 }

--- a/Tests/Manager/ClientManagerTest.php
+++ b/Tests/Manager/ClientManagerTest.php
@@ -6,8 +6,27 @@ use Dizda\CloudBackupBundle\Client\DownloadableClientInterface;
 use Dizda\CloudBackupBundle\Manager\ClientManager;
 use Psr\Log\LoggerInterface;
 
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class ClientManagerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Compatibility for older PHPUnit versions
+     *
+     * @param string $originalClassName
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($originalClassName) {
+        if(is_callable(array('parent', 'createMock'))) {
+            return parent::createMock($originalClassName);
+        } else {
+            return $this->getMock($originalClassName);
+        }
+    }
+
     /**
      * @test
      */

--- a/Tests/Manager/RestoreManagerTest.php
+++ b/Tests/Manager/RestoreManagerTest.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-class RestoreManagerTest extends \PHPUnit_Framework_TestCase
+class RestoreManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
@@ -30,9 +30,9 @@ class RestoreManagerTest extends \PHPUnit_Framework_TestCase
         $clientManagerMock->expects($this->once())->method('download')->willReturn($fileMock);
         $processorManagerMock = $this->getMockBuilder(ProcessorManager::class)->disableOriginalConstructor()->getMock();
         $processorManagerMock->expects($this->once())->method('uncompress');
-        $eventDispatcherMock = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcherMock->expects($this->once())->method('dispatch')->with(RestoreEvent::RESTORE_COMPLETED);
-        $filesystemMock = $this->getMock(Filesystem::class);
+        $filesystemMock = $this->createMock(Filesystem::class);
 
         $restoreManager = new RestoreManager(
             $databaseManagerMock,
@@ -60,9 +60,9 @@ class RestoreManagerTest extends \PHPUnit_Framework_TestCase
         $clientManagerMock->expects($this->never())->method('download');
         $processorManagerMock = $this->getMockBuilder(ProcessorManager::class)->disableOriginalConstructor()->getMock();
         $processorManagerMock->expects($this->never())->method('uncompress');
-        $eventDispatcherMock = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcherMock->expects($this->never())->method('dispatch');
-        $filesystemMock = $this->getMock(Filesystem::class);
+        $filesystemMock = $this->createMock(Filesystem::class);
 
         $restoreManager = new RestoreManager(
             $databaseManagerMock,
@@ -88,12 +88,12 @@ class RestoreManagerTest extends \PHPUnit_Framework_TestCase
         $clientManagerMock->expects($this->never())->method('download');
         $processorManagerMock = $this->getMockBuilder(ProcessorManager::class)->disableOriginalConstructor()->getMock();
         $processorManagerMock->expects($this->never())->method('uncompress');
-        $eventDispatcherMock = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcherMock->expects($this->any())->method('dispatch')->with(
-            new \PHPUnit_Framework_Constraint_Not(RestoreEvent::RESTORE_COMPLETED)
+            new \PHPUnit\Framework\Constraint\LogicalNot(RestoreEvent::RESTORE_COMPLETED)
         );
         $eventDispatcherMock->expects($this->once())->method('dispatch')->with(RestoreFailedEvent::RESTORE_FAILED);
-        $filesystemMock = $this->getMock(Filesystem::class);
+        $filesystemMock = $this->createMock(Filesystem::class);
         $filesystemMock->expects($this->once())->method('mkdir')->will($this->throwException(new \Exception()));
 
         $restoreManager = new RestoreManager(

--- a/Tests/Processor/SevenZipTest.php
+++ b/Tests/Processor/SevenZipTest.php
@@ -7,7 +7,7 @@ use Dizda\CloudBackupBundle\Processor\SevenZipProcessor;
 /**
  * Class SevenZipTest.
  */
-class SevenZipTest extends \PHPUnit_Framework_TestCase
+class SevenZipTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test different commands.

--- a/Tests/Processor/SevenZipTest.php
+++ b/Tests/Processor/SevenZipTest.php
@@ -7,6 +7,11 @@ use Dizda\CloudBackupBundle\Processor\SevenZipProcessor;
 /**
  * Class SevenZipTest.
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class SevenZipTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Tests/Processor/TarTest.php
+++ b/Tests/Processor/TarTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Process\ProcessUtils;
 /**
  * Class TarTest.
  */
-class TarTest extends \PHPUnit_Framework_TestCase
+class TarTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test different commands.

--- a/Tests/Processor/TarTest.php
+++ b/Tests/Processor/TarTest.php
@@ -8,6 +8,11 @@ use Symfony\Component\Process\ProcessUtils;
 /**
  * Class TarTest.
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class TarTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Tests/Processor/ZipTest.php
+++ b/Tests/Processor/ZipTest.php
@@ -7,7 +7,7 @@ use Dizda\CloudBackupBundle\Processor\ZipProcessor;
 /**
  * Class ZipTest.
  */
-class ZipTest extends \PHPUnit_Framework_TestCase
+class ZipTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test different commands.

--- a/Tests/Processor/ZipTest.php
+++ b/Tests/Processor/ZipTest.php
@@ -7,6 +7,11 @@ use Dizda\CloudBackupBundle\Processor\ZipProcessor;
 /**
  * Class ZipTest.
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class ZipTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Tests/Splitter/ZipSplitTest.php
+++ b/Tests/Splitter/ZipSplitTest.php
@@ -7,7 +7,7 @@ use Dizda\CloudBackupBundle\Splitter\ZipSplitSplitter;
 /**
  * @author Nick Doulgeridis
  */
-class ZipSplitTest extends \PHPUnit_Framework_TestCase
+class ZipSplitTest extends \PHPUnit\Framework\TestCase
 {
     public function testZipSplitCommand()
     {

--- a/Tests/Splitter/ZipSplitTest.php
+++ b/Tests/Splitter/ZipSplitTest.php
@@ -7,6 +7,11 @@ use Dizda\CloudBackupBundle\Splitter\ZipSplitSplitter;
 /**
  * @author Nick Doulgeridis
  */
+// backward compatibility
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}
 class ZipSplitTest extends \PHPUnit\Framework\TestCase
 {
     public function testZipSplitCommand()


### PR DESCRIPTION
mysqldump : 
- added options to pass `--single-transaction`. This mainly avoids locking mysql database during dumps. Slows down dumps a bit.

mysql :
- pass host/port to command line if they are specified.