### PR TITLE
Allow Restore of Multiple Databases Types

### DIFF
--- a/Manager/DatabaseManager.php
+++ b/Manager/DatabaseManager.php
@@ -60,13 +60,16 @@ class DatabaseManager
      */
     public function restore()
     {
+        $Restored = 0;
         foreach ($this->children as $child) {
             if ($child instanceof RestorableDatabaseInterface) {
                 $child->restore();
-                return;
+                $Restored++;
             }
         }
-
-        throw MissingRestorableDatabaseException::create();
+        
+        if ( !$Restored ) {
+            throw MissingRestorableDatabaseException::create();            
+        } 
     }
 }


### PR DESCRIPTION
Currently if you set more than one Database format, only the first one is restored. 
Moreover, no user message is present.